### PR TITLE
Fix `offline-github-changelog` command not found error

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -15,7 +15,7 @@ after_publish:
   - 'git push --follow-tags origin master:master'
 
 changelog:
-  - offline-github-changelog > CHANGELOG.md
+  - npx offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - 'git push origin master:master'

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ after_publish:
   - git push --follow-tags origin master:master
 
 changelog:
-  - offline-github-changelog > CHANGELOG.md
+  - npx offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - git push origin master:master

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -23,7 +23,7 @@ const buildReleaseConfig = () => {
     ],
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [
-      'offline-github-changelog > CHANGELOG.md',
+      'npx offline-github-changelog > CHANGELOG.md',
       'git add CHANGELOG.md',
       'git commit --allow-empty -m "Update changelog"',
       'git push origin master:master'


### PR DESCRIPTION
Executes `offline-github-changelog` through `npx`.

@zendesk/delta 