### PR TITLE
Extend `package.json` with a binary entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "version": "0.1.1",
   "main": "src/index.js",
+  "bin": {
+    "node-publisher": "./bin/node-publisher"
+  },
   "scripts": {
     "coverage": "jest --coverage",
     "lint": "eslint ./**/*.js",


### PR DESCRIPTION
This PR adds a `bin` entry to install the executable into the PATH.

@zendesk/delta 