### PR TITLE
Run binaries of local packages either using `yarn` or `npx`

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -5,7 +5,7 @@ prepare:
   - git diff-index --quiet HEAD --
   - git checkout master
   - git pull --rebase
-  - '[[ -f .nvmrc ]] && check-node-version --node $(cat .nvmrc) --yarn 1.7'
+  - '[[ -f .nvmrc ]] && yarn check-node-version --node $(cat .nvmrc) --yarn 1.7'
   - yarn install
 
 test:
@@ -15,7 +15,7 @@ after_publish:
   - 'git push --follow-tags origin master:master'
 
 changelog:
-  - npx offline-github-changelog > CHANGELOG.md
+  - yarn offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - 'git push origin master:master'

--- a/README.md
+++ b/README.md
@@ -17,13 +17,35 @@ yarn add --dev @zendesk/node-publisher
 
 ## Usage
 
-To release a new version of your package, run:
+### Global installation
 
 ```
 node-publisher release (major | minor | patch)
 ```
 
-To customize your release process, run:
+### Local installation
+#### With NPM
+
+```
+npx node-publisher release (major | minor | patch)
+```
+
+#### With Yarn
+```
+yarn node-publisher release (major | minor | patch)
+```
+
+#### Through package.json scripts
+Create a `scripts` entry in your `package.json`, such as:
+
+`"release": "node-publisher release"`
+
+and run:
+```
+(npm run|yarn) release -- (major | minor | patch)
+```
+
+## Customize the release process
 
 ```
 node-publisher eject
@@ -31,7 +53,7 @@ node-publisher eject
 
 After ejecting, a `.release.yml` file will appear in the root directory of your package. You can override the default behaviour by modifying this file.
 
-### Prerequisites
+## Prerequisites
 
 The default release process assumes a `.nvmrc` file present in the root of your package. In case it is missing, the release fails in its preparation phase.
 
@@ -69,7 +91,7 @@ prepare:
   - git diff-index --quiet HEAD --
   - git checkout master
   - git pull --rebase
-  - '[[ -f .nvmrc ]] && check-node-version --node $(cat .nvmrc)'
+  - '[[ -f .nvmrc ]] && yarn check-node-version --node $(cat .nvmrc)'
   - yarn install
 
 test:
@@ -84,7 +106,7 @@ after_publish:
   - git push --follow-tags origin master:master
 
 changelog:
-  - npx offline-github-changelog > CHANGELOG.md
+  - yarn offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - git push origin master:master

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -5,6 +5,8 @@ const readReleaseConfig = str => yaml.safeLoad(str);
 
 const buildReleaseConfig = () => {
   const client = npmClient();
+  const scriptRunner = client === 'yarn' ? 'yarn' : 'npm run';
+  const packageRunner = client === 'yarn' ? 'yarn' : 'npx';
 
   return {
     rollback: true,
@@ -12,18 +14,18 @@ const buildReleaseConfig = () => {
       'git diff-index --quiet HEAD --',
       'git checkout master',
       'git pull --rebase',
-      '[[ -f .nvmrc ]] && check-node-version --node $(cat .nvmrc)',
+      `[[ -f .nvmrc ]] && ${packageRunner} check-node-version --node $(cat .nvmrc)`,
       `${client} install`
     ],
-    test: [`${client === 'yarn' ? 'yarn' : 'npm run'} travis`],
+    test: [`${scriptRunner} travis`],
     build: [
-      `${client === 'yarn' ? 'yarn' : 'npm run'} build`,
+      `${scriptRunner} build`,
       'git add dist/bundle.js',
       'git commit -m "Update build file"'
     ],
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [
-      'npx offline-github-changelog > CHANGELOG.md',
+      `${packageRunner} offline-github-changelog > CHANGELOG.md`,
       'git add CHANGELOG.md',
       'git commit --allow-empty -m "Update changelog"',
       'git push origin master:master'


### PR DESCRIPTION
The idea is not to require global installations of any dependency. 

- To run their local installation, this PR calls the packages through either `yarn` or `npx` based on the *detected* npm client. 
- It changes the package's own release configuration accordingly.
- It educates the user through README about different ways of using the package.

@zendesk/delta 