### PR TITLE
Call local package bins directly instead of relying on `yarn` or `npx`

### DIFF
--- a/.release.yml
+++ b/.release.yml
@@ -5,7 +5,7 @@ prepare:
   - git diff-index --quiet HEAD --
   - git checkout master
   - git pull --rebase
-  - '[[ -f .nvmrc ]] && yarn check-node-version --node $(cat .nvmrc) --yarn 1.7'
+  - '[[ -f .nvmrc ]] && ./node_modules/.bin/check-node-version --node $(cat .nvmrc) --yarn 1.7'
   - yarn install
 
 test:
@@ -15,7 +15,7 @@ after_publish:
   - 'git push --follow-tags origin master:master'
 
 changelog:
-  - yarn offline-github-changelog > CHANGELOG.md
+  - ./node_modules/.bin/offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - 'git push origin master:master'

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ prepare:
   - git diff-index --quiet HEAD --
   - git checkout master
   - git pull --rebase
-  - '[[ -f .nvmrc ]] && yarn check-node-version --node $(cat .nvmrc)'
+  - '[[ -f .nvmrc ]] && ./node_modules/.bin/check-node-version --node $(cat .nvmrc)'
   - yarn install
 
 test:
@@ -106,7 +106,7 @@ after_publish:
   - git push --follow-tags origin master:master
 
 changelog:
-  - yarn offline-github-changelog > CHANGELOG.md
+  - ./node_modules/.bin/offline-github-changelog > CHANGELOG.md
   - git add CHANGELOG.md
   - git commit --allow-empty -m "Update changelog"
   - git push origin master:master

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -5,8 +5,8 @@ const readReleaseConfig = str => yaml.safeLoad(str);
 
 const buildReleaseConfig = () => {
   const client = npmClient();
+  const binPathPrefix = './node_modules/.bin/';
   const scriptRunner = client === 'yarn' ? 'yarn' : 'npm run';
-  const packageRunner = client === 'yarn' ? 'yarn' : 'npx';
 
   return {
     rollback: true,
@@ -14,7 +14,7 @@ const buildReleaseConfig = () => {
       'git diff-index --quiet HEAD --',
       'git checkout master',
       'git pull --rebase',
-      `[[ -f .nvmrc ]] && ${packageRunner} check-node-version --node $(cat .nvmrc)`,
+      `[[ -f .nvmrc ]] && ${binPathPrefix}check-node-version --node $(cat .nvmrc)`,
       `${client} install`
     ],
     test: [`${scriptRunner} travis`],
@@ -25,7 +25,7 @@ const buildReleaseConfig = () => {
     ],
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [
-      `${packageRunner} offline-github-changelog > CHANGELOG.md`,
+      `${binPathPrefix}offline-github-changelog > CHANGELOG.md`,
       'git add CHANGELOG.md',
       'git commit --allow-empty -m "Update changelog"',
       'git push origin master:master'


### PR DESCRIPTION
When yarn is the detected package manager, the `CHANGELOG.md` gets polluted (see [example](https://github.com/zendesk/node-publisher/commit/ccf818ed54a1e50a40f7f41b214e30b15e3e2b6c)) with yarn specific output. I tried to find some configuration to remove that output and found none.

Instead of using a package manager specific way of calling the binaries of locally installed package, I propose to just call it directly through path.

@zendesk/delta 