### PR TITLE
Relocate offline-github-changelog in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "check-node-version": "3.2.0",
     "commander": "2.15.1",
-    "js-yaml": "3.12.0"
+    "js-yaml": "3.12.0",
+    "offline-github-changelog": "1.2.0"
   },
   "devDependencies": {
     "babel-eslint": "8.2.3",
@@ -31,7 +32,6 @@
     "eslint-plugin-jest": "21.17.0",
     "jest": "23.1.0",
     "lint-staged": "7.2.0",
-    "offline-github-changelog": "1.2.0",
     "pre-commit": "1.2.2",
     "prettier": "1.13.5",
     "prettier-package-json": "1.6.0"


### PR DESCRIPTION
This PR moves `offline-github-changelog` from devDependencies to dependencies as it is used by the code itself making its use more transparent. Thanks @luis-almeida for the suggestion.

@zendesk/delta 

### Risks
None