### PR TITLE
Remove build file naming assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ After ejecting, a `.release.yml` file will appear in the root directory of your 
 
 ## Prerequisites
 
-The default release process assumes a `.nvmrc` file present in the root of your package. In case it is missing, the release fails in its preparation phase.
+The default release process assumes the following:
+
+- The master branch is called `master`.
+- A `.nvmrc` file is present in the root of your package. In case it is missing, the release fails in its preparation phase.
+- A build process is assumed with build files being generated in the `dist/` directory.
 
 ## Lifecycle
 
@@ -105,7 +109,7 @@ test:
 
 build:
   - yarn build
-  - git add dist/bundle.js
+  - git add dist/
   - git commit -m "Update build file"
 
 after_publish:

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -20,7 +20,7 @@ const buildReleaseConfig = () => {
     test: [`${scriptRunner} travis`],
     build: [
       `${scriptRunner} build`,
-      'git add dist/bundle.js',
+      'git add dist/',
       'git commit -m "Update build file"'
     ],
     after_publish: ['git push --follow-tags origin master:master'],


### PR DESCRIPTION
This PR removes the following assumptions:
- the name of the build file being `bundle.js`,
- the number of build files being limited to `1`.

The removal of the above mentioned assumptions should help the adoption of the tool. It could result in less number of ejections due the configuration of name(s) of bundle(s) to be added to the git index for committing.

@zendesk/delta 