### PR TITLE
Clarifies getting started and simplifies usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a configurable release automation tool for node packages inspired by Travis CI. It has a default configuration, which can be overriden in case of need. As a convention, this release tool defines a set of hooks that represent the release lifecycle. The default configuration can be overriden by redefining what commands should run under which hook in a `.release.yml` file. The hooks are listed under the [Lifecycle](#lifecycle) section.
 
 ## Getting started
-Install the package:
+### 1. Install the package:
 
 ```
 npm install @zendesk/node-publisher --save-dev
@@ -15,32 +15,23 @@ or
 yarn add --dev @zendesk/node-publisher
 ```
 
+### 2. Add following scripts to `package.json`
+```js
+// package.json
+// make sure the `travis` command exits with a status that can be read from the terminal with $?
+
+{
+  ...,
+  "sctipts": {
+    "travis": "your linting/testing/etc. command here",
+    "release": "node-publisher release",
+  },
+  ...
+}
+```
+
 ## Usage
 
-### Global installation
-
-```
-node-publisher release (major | minor | patch)
-```
-
-### Local installation
-#### With NPM
-
-```
-npx node-publisher release (major | minor | patch)
-```
-
-#### With Yarn
-```
-yarn node-publisher release (major | minor | patch)
-```
-
-#### Through package.json scripts
-Create a `scripts` entry in your `package.json`, such as:
-
-`"release": "node-publisher release"`
-
-and run:
 ```
 npm run release -- (major | minor | patch)
 ```


### PR DESCRIPTION
After integrating the tool into couple of existing projects, some caveats came onto surface. The most often occurred problems were:
- Missing `yarn travis` script in `package.json`,
- `yarn travis` did not exit, so the exit status could not be read by the tool.

I thought the README could be more clear about how to integrate the tool with an existing or new project and warn about the above problems.

@zendesk/delta 

### Risks
None.