### PR TITLE
Allow unmodified bundles to be committed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ test:
 build:
   - yarn build
   - git add dist/
-  - git commit -m "Update build file"
+  - git commit --allow-empty -m "Update build file"
 
 after_publish:
   - git push --follow-tags origin master:master

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -21,7 +21,7 @@ const buildReleaseConfig = () => {
     build: [
       `${scriptRunner} build`,
       'git add dist/',
-      'git commit -m "Update build file"'
+      'git commit --allow-empty -m "Update build file"'
     ],
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [


### PR DESCRIPTION
Prevents the publishing process from failing in case there are no changes introduced to the bundles themselves.

@zendesk/delta 