### PR TITLE
Autodetect whether package needs to be built during release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The default release process assumes the following:
 
 - The master branch is called `master`.
 - A `.nvmrc` file is present in the root of your package. In case it is missing, the release fails in its preparation phase.
+- The tool expects the build generation script to be called `build`. Otherwise, the build step is skipped.
 
 ## Lifecycle
 
@@ -82,7 +83,7 @@ The lifecycle hooks can be redefined in the form of a configurable YAML file. Ad
 * `rollback [Boolean]` - rolls back to the latest commit fetched after the `prepare` step. The rollback itself happens in the `after_failure` step and only if this flag is set to `true`.
 
 ### Default configuration
-The exact configuration depends on the npm client being used. In case, it is yarn, the default configuration will look like this:
+The exact configuration depends on the npm client being used and the contents of your `package.json` file. In case you use yarn, the default configuration will look like this:
 
 ```yaml
 rollback: true
@@ -97,7 +98,7 @@ prepare:
 test:
   - yarn travis
 
-build:
+build: # only if "build" is defined as a script in your `package.json`
   - yarn build
   - git add .
   - git commit --allow-empty -m "Update build file"

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -12,14 +12,14 @@ const __setMockFiles = newMockFiles => {
   }
 };
 
-let readFileSyncRetValue;
-const __setReadFileSyncReturnValue = val => {
-  readFileSyncRetValue = val;
+const readFileSyncRetValue = {};
+const __setReadFileSyncReturnValue = (file, val) => {
+  readFileSyncRetValue[path.resolve(process.env.PWD, file)] = val;
 };
 
 const existsSync = path => mockFiles.includes(path);
 
-const readFileSync = path => readFileSyncRetValue;
+const readFileSync = path => readFileSyncRetValue[path];
 
 fs.__setMockFiles = __setMockFiles;
 fs.__setReadFileSyncReturnValue = __setReadFileSyncReturnValue;

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -1,5 +1,6 @@
 const yaml = require('js-yaml');
 const { npmClient } = require('../client');
+const { isBuildDefined } = require('../');
 
 const readReleaseConfig = str => yaml.safeLoad(str);
 
@@ -8,7 +9,7 @@ const buildReleaseConfig = () => {
   const binPathPrefix = './node_modules/.bin/';
   const scriptRunner = client === 'yarn' ? 'yarn' : 'npm run';
 
-  return {
+  const config = {
     rollback: true,
     prepare: [
       'git diff-index --quiet HEAD --',
@@ -18,11 +19,6 @@ const buildReleaseConfig = () => {
       `${client} install`
     ],
     test: [`${scriptRunner} travis`],
-    build: [
-      `${scriptRunner} build`,
-      'git add .',
-      'git commit --allow-empty -m "Update build file"'
-    ],
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [
       `${binPathPrefix}offline-github-changelog > CHANGELOG.md`,
@@ -31,6 +27,16 @@ const buildReleaseConfig = () => {
       'git push origin master:master'
     ]
   };
+
+  if (isBuildDefined()) {
+    config.build = [
+      `${scriptRunner} build`,
+      'git add .',
+      'git commit --allow-empty -m "Update build file"'
+    ];
+  }
+
+  return config;
 };
 
 module.exports = {

--- a/src/utils/config/index.spec.js
+++ b/src/utils/config/index.spec.js
@@ -3,31 +3,66 @@ const { buildReleaseConfig } = require('./');
 jest.mock('fs');
 
 describe('buildReleaseConfig', () => {
-  describe('when npm is the detected npm client', () => {
-    const MOCKED_FILES = ['package-lock.json'];
+  describe('when build script is defined in package.json', () => {
+    const mockPkg = {
+      scripts: {
+        build: './build'
+      }
+    };
 
-    it('returns the correct configuration', () => {
-      require('fs').__setMockFiles(MOCKED_FILES);
+    describe('and npm is the detected npm client', () => {
+      const MOCKED_FILES = ['package-lock.json', 'package.json'];
 
-      const config = buildReleaseConfig();
+      it('returns a configuration with the build step', () => {
+        require('fs').__setMockFiles(MOCKED_FILES);
+        require('fs').__setReadFileSyncReturnValue(
+          'package.json',
+          JSON.stringify(mockPkg)
+        );
 
-      expect(config.prepare[config.prepare.length - 1]).toBe('npm install');
-      expect(config.test[0]).toBe('npm run travis');
-      expect(config.build[0]).toBe('npm run build');
+        const config = buildReleaseConfig();
+
+        expect(config.prepare[config.prepare.length - 1]).toBe('npm install');
+        expect(config.test[0]).toBe('npm run travis');
+        expect(config.build[0]).toBe('npm run build');
+      });
+    });
+
+    describe('and yarn is the detected npm client', () => {
+      const MOCKED_FILES = ['yarn.lock', 'package.json'];
+
+      it('returns a configuration with the build step', () => {
+        require('fs').__setMockFiles(MOCKED_FILES);
+        require('fs').__setReadFileSyncReturnValue(
+          'package.json',
+          JSON.stringify(mockPkg)
+        );
+
+        const config = buildReleaseConfig();
+
+        expect(config.prepare[config.prepare.length - 1]).toBe('yarn install');
+        expect(config.test[0]).toBe('yarn travis');
+        expect(config.build[0]).toBe('yarn build');
+      });
     });
   });
 
-  describe('when yarn is the detected npm client', () => {
-    const MOCKED_FILES = ['yarn.lock'];
+  describe('when build script is not defined in package.json', () => {
+    const MOCKED_FILES = ['yarn.lock', 'package.json'];
+    const mockPkg = {
+      scripts: {}
+    };
 
-    it('returns the correct configuration', () => {
+    it('returns a configuration without the build step', () => {
       require('fs').__setMockFiles(MOCKED_FILES);
+      require('fs').__setReadFileSyncReturnValue(
+        'package.json',
+        JSON.stringify(mockPkg)
+      );
 
       const config = buildReleaseConfig();
 
-      expect(config.prepare[config.prepare.length - 1]).toBe('yarn install');
-      expect(config.test[0]).toBe('yarn travis');
-      expect(config.build[0]).toBe('yarn build');
+      expect(config.build).toBeUndefined();
     });
   });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,13 +4,18 @@ const command = require('./command');
 const { readReleaseConfig, buildReleaseConfig } = require('./config');
 
 const VERSIONS = ['major', 'minor', 'patch'];
+const packageJson = path.resolve(process.env.PWD, 'package.json');
 
 const validateEnvironment = () => {
-  const packageJson = path.resolve(process.env.PWD, 'package.json');
-
   if (!fs.existsSync(packageJson)) {
     throw new Error('Run this script from the root of your package.');
   }
+};
+
+const isBuildDefined = () => {
+  const pkg = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+
+  return pkg.scripts && pkg.scripts.build;
 };
 
 const loadReleaseConfig = () => {
@@ -43,6 +48,7 @@ const rollbackCommit = commitId => command.exec(`git reset --hard ${commitId}`);
 
 module.exports = {
   validateEnvironment,
+  isBuildDefined,
   loadReleaseConfig,
   validVersion,
   execCommands,

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -41,7 +41,10 @@ describe('loadReleaseConfig', () => {
 
     it('loads the custom configuration', () => {
       require('fs').__setMockFiles(MOCKED_FILES);
-      require('fs').__setReadFileSyncReturnValue('file contents');
+      require('fs').__setReadFileSyncReturnValue(
+        '.release.yml',
+        'file contents'
+      );
       config.readReleaseConfig.mockReturnValue('configuration');
 
       const strConfig = utils.loadReleaseConfig();


### PR DESCRIPTION
This PR eases the adoption of the tool by autodetecting the need for generating build file(s). It looks into the `package.json` file and searches for the `build` script which is the assumed name for the build triggering script. In case the script is not found, the build step will be skipped.

@zendesk/delta 

### Risks
Low - might break the release process where the build step is required.