### PR TITLE
Remove the assumption about the output build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The default release process assumes the following:
 
 - The master branch is called `master`.
 - A `.nvmrc` file is present in the root of your package. In case it is missing, the release fails in its preparation phase.
-- A build process is assumed with build files being generated in the `dist/` directory.
 
 ## Lifecycle
 
@@ -100,7 +99,7 @@ test:
 
 build:
   - yarn build
-  - git add dist/
+  - git add .
   - git commit --allow-empty -m "Update build file"
 
 after_publish:

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -20,7 +20,7 @@ const buildReleaseConfig = () => {
     test: [`${scriptRunner} travis`],
     build: [
       `${scriptRunner} build`,
-      'git add dist/',
+      'git add .',
       'git commit --allow-empty -m "Update build file"'
     ],
     after_publish: ['git push --follow-tags origin master:master'],


### PR DESCRIPTION
Since the working tree is checked against the git index in the very beginning of the release process, no change should be committed other than what the build step produces. 

When creating custom release configurations, one should keep in mind to clean up any temporary files.

@zendesk/delta 

### Risks
None.