### PR TITLE
Fix the order of steps in .release.yml when ejected

### DIFF
--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -17,6 +17,7 @@ const buildReleaseConfig = env => {
       `${client} install`
     ],
     test: [`${scriptRunner} ${env.testRunner}`],
+    build: null,
     after_publish: ['git push --follow-tags origin master:master'],
     changelog: [
       `${binPathPrefix}offline-github-changelog > CHANGELOG.md`,
@@ -32,6 +33,8 @@ const buildReleaseConfig = env => {
       'git add .',
       'git commit --allow-empty -m "Update build file"'
     ];
+  } else {
+    delete config.build;
   }
 
   return config;


### PR DESCRIPTION
With the current implementation, the build step would be defined as the last in the `release.yml` file after ejecting.
This PR fixes the order which should follow the order of the life cycle steps as defined in the code and described in the README. 

@zendesk/delta 

### Risks
The change does not affect the functionality, it is only about the aesthetics.