### PR TITLE
Fix publishing using Lerna

### DIFF
--- a/src/client/lerna.js
+++ b/src/client/lerna.js
@@ -1,5 +1,5 @@
-const publish = ({ execCommand }) => {
-  execCommand('lerna publish');
+const publish = (nextVersion, { execCommand }) => {
+  execCommand(`lerna publish ${nextVersion}`);
 };
 
 module.exports = {

--- a/src/client/lerna.spec.js
+++ b/src/client/lerna.spec.js
@@ -6,7 +6,7 @@ describe('publish', () => {
   };
 
   it('publishes new version', () => {
-    expect(() => publish(options)).not.toThrow();
-    expect(options.execCommand.mock.calls[0][0]).toBe('lerna publish');
+    expect(() => publish('patch', options)).not.toThrow();
+    expect(options.execCommand.mock.calls[0][0]).toBe('lerna publish patch');
   });
 });


### PR DESCRIPTION
When publishing with lerna, the release fails with the message `ERROR: execCommand is not a function`. It is cause because the first param passed to the `publish` function is always the version.
~Since Lerna does not have an option to explicitly state the next version through the command line, the user needs to wait for the prompt. Adding an "ignored param" should fix the issue.~

Just realized, that Lerna also supports predefining the next version through command line options. `lerna publish` supports all the options provided by `lerna version` plus some extra. `lerna version` [bumps the version](https://github.com/lerna/lerna/tree/master/commands/version#positionals) based on the option given.

@zendesk/delta 

### Risks
None.