### PR TITLE
Commit build files only when there are files staged

### DIFF
--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -30,8 +30,7 @@ const buildReleaseConfig = env => {
   if (env.withBuildStep) {
     config.build = [
       `${scriptRunner} build`,
-      'git add .',
-      'git commit --allow-empty -m "Update build file"'
+      'git diff --staged --quiet || git commit -am "Update build file"'
     ];
   } else {
     delete config.build;


### PR DESCRIPTION
Sometimes the build process yields files that are gitignored. In that case, no empty commit should be generated.

@zendesk/delta @sunesimonsen 