### PR TITLE
Add publish config to be able to release with yarn again

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "prettier": "1.13.5",
     "prettier-package-json": "1.6.0"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "licenses": [
     {
       "type": "Apache 2.0",


### PR DESCRIPTION
In order to publish the package to the NPM registry with yarn, it seems like we need the configuration again.

@sunesimonsen 