### PR TITLE
Add details to package.json + minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <p align="center">
-  <img
-    alt="Node Publisher by Zendesk"
-    src="https://github.com/zendesk/node-publisher/raw/master/assets/logo.png"
-    width="400"
-  />
+  <a href="https://github.com/zendesk/node-publisher">
+    <img
+      alt="Node Publisher by Zendesk"
+      src="https://github.com/zendesk/node-publisher/raw/master/assets/logo.png"
+      width="500"
+    />
+  </a>
 </p>
 
 This is a configurable release automation tool for node packages inspired by [create-react-app](https://github.com/facebook/create-react-app) and [Travis CI](https://travis-ci.org/). It has a default configuration, which can be overriden in case of need. As a convention, this release tool defines a set of hooks that represent the release lifecycle. The default configuration can be overriden by redefining what commands should run under which hook in a `.release.yml` file. The hooks are listed under the [Lifecycle](#lifecycle) section.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn release (major | minor | patch)
 # Customize the release process
 
 ```
-node-publisher eject
+npx node-publisher eject
 ```
 
 After ejecting, a `.release.yml` file will appear in the root directory of your package. You can override the default behaviour by modifying this file.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 This is a configurable release automation tool for node packages inspired by [create-react-app](https://github.com/facebook/create-react-app) and [Travis CI](https://travis-ci.org/). It has a default configuration, which can be overriden in case of need. As a convention, this release tool defines a set of hooks that represent the release lifecycle. The default configuration can be overriden by redefining what commands should run under which hook in a `.release.yml` file. The hooks are listed under the [Lifecycle](#lifecycle) section.
 
+[![NPM version](https://badge.fury.io/js/node-publisher.svg)](https://badge.fury.io/js/node-publisher)
+[![Build Status](https://travis-ci.com/zendesk/node-publisher.svg?branch=master)](https://travis-ci.com/zendesk/node-publisher)
+
 # Getting started
 ## 1. Install the package:
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "node-publisher",
   "description": "A configurable release automation tool inspired by create-react-app and Travis CI.",
   "author": "Attila Večerek <avecerek@zendesk.com>",
+  "homepage": "https://github.com/zendesk/node-publisher#readme",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zendesk/node-publisher.git"
+    "url": "git+ssh://git@github.com/zendesk/node-publisher.git"
+  },
+  "bugs": {
+    "url": "https://github.com/zendesk/node-publisher/issues"
   },
   "version": "1.1.0",
   "main": "src/index.js",
@@ -36,6 +40,12 @@
     "prettier": "1.13.5",
     "prettier-package-json": "1.6.0"
   },
+  "keywords": [
+    "lerna",
+    "npm",
+    "release-management",
+    "yarn"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
The main reason to add the details is to release a patch so that the repository value gets repopulated on [npmjs.com](https://www.npmjs.com/package/node-publisher).

The proposed keywords are: `release-management`, `npm`, `yarn`, and `lerna`.
Adds a `homepage` and a `bugs` entry, as well.

@sunesimonsen any other ideas for keywords?