### PR TITLE
Support multiple release configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ npx node-publisher eject
 
 After ejecting, a `.release.yml` file will appear in the root directory of your package. You can override the default behaviour by modifying this file.
 
+## Multiple configuration files
+
+Using the `--config` release param, it is possible to specify which file to load the release steps from. This way, one can have different release procedures for different purposes.
+
+Example:
+
+```js
+// package.json
+
+{
+  "scripts": {
+    "release": "node-publisher release",
+    "pre-release": "node-publisher release --config path/to/.pre-release.yml"
+  }
+}
+```
+
 # Prerequisites
 
 The default release process assumes the following:

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -8,18 +8,21 @@ let mockFiles = [];
 const __setMockFiles = newMockFiles => {
   mockFiles = [];
   for (const file of newMockFiles) {
-    mockFiles.push(path.resolve(process.env.PWD, file));
+    mockFiles.push(normalizePath(file));
   }
 };
 
 const readFileSyncRetValue = {};
 const __setReadFileSyncReturnValue = (file, val) => {
-  readFileSyncRetValue[path.resolve(process.env.PWD, file)] = val;
+  readFileSyncRetValue[normalizePath(file)] = val;
 };
 
 const existsSync = path => mockFiles.includes(path);
 
 const readFileSync = path => readFileSyncRetValue[path];
+
+const normalizePath = p =>
+  path.isAbsolute(p) ? p : path.resolve(process.env.PWD, p);
 
 fs.__setMockFiles = __setMockFiles;
 fs.__setReadFileSyncReturnValue = __setReadFileSyncReturnValue;

--- a/bin/node-publisher-release
+++ b/bin/node-publisher-release
@@ -8,11 +8,12 @@ program
   .description('Releases your package under the specified version.')
   .option('[version]', 'specify the release version; accepts the versions of the npm client in use.')
   .option('--preid <prerelease-id>', 'specify the prerelease identifier (pre, alpha, beta, etc.).')
+  .option('-c, --config <path>', 'set config path. Defaults to ./.release.yml')
   .parse(process.argv);
 
 try {
   release({
-    env: buildReleaseEnvironment({}),
+    env: buildReleaseEnvironment({ configPath: program.config }),
     nextVersion: program.args[0],
     preid: program.preid
   });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,6 +3,7 @@ const path = require('path');
 const VERSIONS = ['major', 'minor', 'patch'];
 const DEFAULT_TEST_RUNNER = 'travis';
 const VALID_TEST_RUNNERS = [DEFAULT_TEST_RUNNER, 'ci'];
+const DEFAULT_CONFIG_PATH = '.release.yml';
 const PACKAGE_JSON_PATH = path.resolve(process.env.PWD, 'package.json');
 const LERNA_JSON_PATH = path.resolve(process.env.PWD, 'lerna.json');
 
@@ -10,6 +11,7 @@ module.exports = {
   VERSIONS,
   DEFAULT_TEST_RUNNER,
   VALID_TEST_RUNNERS,
+  DEFAULT_CONFIG_PATH,
   PACKAGE_JSON_PATH,
   LERNA_JSON_PATH
 };


### PR DESCRIPTION
This PR partly addresses #25. It enables different release configurations to be used for different purposes. For example, one may want to have different release process for beta, alpha, etc. releases.

cc: @sunesimonsen @GiladShoham