### PR TITLE
Remove version constraints and add prerelease option

### DIFF
--- a/bin/node-publisher-release
+++ b/bin/node-publisher-release
@@ -3,20 +3,17 @@
 const program = require('commander');
 const release = require('../');
 const { buildReleaseEnvironment } = require('../src/utils');
-const { validateVersion } = require('../src/utils/validations');
 
 program
   .description('Releases your package under the specified version.')
-  .option('[version]', 'specify the release version: (major|minor|patch)')
+  .option('[version]', 'specify the release version; accepts the versions of the npm client in use.')
   .parse(process.argv);
 
 try {
-  const env = buildReleaseEnvironment({});
-  const nextVersion = program.args[0];
-
-  validateVersion(nextVersion, env);
-  
-  release({ env, nextVersion });
+  release({
+    env: buildReleaseEnvironment({}),
+    nextVersion: program.args[0]
+  });
 } catch (e) {
   console.error(`ERROR: ${e.message}`);
   process.exit(1);

--- a/bin/node-publisher-release
+++ b/bin/node-publisher-release
@@ -7,12 +7,14 @@ const { buildReleaseEnvironment } = require('../src/utils');
 program
   .description('Releases your package under the specified version.')
   .option('[version]', 'specify the release version; accepts the versions of the npm client in use.')
+  .option('--preid <prerelease-id>', 'specify the prerelease identifier (pre, alpha, beta, etc.).')
   .parse(process.argv);
 
 try {
   release({
     env: buildReleaseEnvironment({}),
-    nextVersion: program.args[0]
+    nextVersion: program.args[0],
+    preid: program.preid
   });
 } catch (e) {
   console.error(`ERROR: ${e.message}`);

--- a/src/client/lerna.js
+++ b/src/client/lerna.js
@@ -1,4 +1,4 @@
-const publish = (nextVersion, { execCommand }) => {
+const publish = ({ nextVersion, execCommand }) => {
   execCommand(`lerna publish ${nextVersion}`);
 };
 

--- a/src/client/lerna.js
+++ b/src/client/lerna.js
@@ -1,5 +1,9 @@
-const publish = ({ nextVersion, execCommand }) => {
-  execCommand(`lerna publish ${nextVersion}`);
+const publish = ({ nextVersion, execCommand, preid }) => {
+  const publishCommand = preid
+    ? `lerna publish ${nextVersion} --preid ${preid}`
+    : `lerna publish ${nextVersion}`;
+
+  execCommand(publishCommand);
 };
 
 module.exports = {

--- a/src/client/lerna.spec.js
+++ b/src/client/lerna.spec.js
@@ -1,13 +1,31 @@
 const { publish } = require('./lerna');
 
 describe('publish', () => {
-  const options = {
-    nextVersion: 'patch',
-    execCommand: jest.fn()
-  };
+  describe('without preid', () => {
+    const options = {
+      nextVersion: 'patch',
+      preid: undefined,
+      execCommand: jest.fn()
+    };
 
-  it('publishes new version', () => {
-    expect(() => publish(options)).not.toThrow();
-    expect(options.execCommand.mock.calls[0][0]).toBe('lerna publish patch');
+    it('publishes new version without a prerelease tag', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe('lerna publish patch');
+    });
+  });
+
+  describe('with preid', () => {
+    const options = {
+      nextVersion: 'major',
+      preid: 'alpha',
+      execCommand: jest.fn()
+    };
+
+    it('publishes new version with a prerelease tag', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe(
+        'lerna publish major --preid alpha'
+      );
+    });
   });
 });

--- a/src/client/lerna.spec.js
+++ b/src/client/lerna.spec.js
@@ -2,11 +2,12 @@ const { publish } = require('./lerna');
 
 describe('publish', () => {
   const options = {
+    nextVersion: 'patch',
     execCommand: jest.fn()
   };
 
   it('publishes new version', () => {
-    expect(() => publish('patch', options)).not.toThrow();
+    expect(() => publish(options)).not.toThrow();
     expect(options.execCommand.mock.calls[0][0]).toBe('lerna publish patch');
   });
 });

--- a/src/client/npm.js
+++ b/src/client/npm.js
@@ -1,5 +1,9 @@
-const publish = ({ nextVersion, execCommand }) => {
-  execCommand(`npm version ${nextVersion}`);
+const publish = ({ nextVersion, execCommand, preid }) => {
+  const versionCommand = preid
+    ? `npm version ${nextVersion} --preid=${preid}`
+    : `npm version ${nextVersion}`;
+
+  execCommand(versionCommand);
   execCommand('npm publish');
 };
 

--- a/src/client/npm.js
+++ b/src/client/npm.js
@@ -1,4 +1,4 @@
-const publish = (nextVersion, { execCommand }) => {
+const publish = ({ nextVersion, execCommand }) => {
   execCommand(`npm version ${nextVersion}`);
   execCommand('npm publish');
 };

--- a/src/client/npm.spec.js
+++ b/src/client/npm.spec.js
@@ -1,14 +1,33 @@
 const { publish } = require('./npm');
 
 describe('publish', () => {
-  const options = {
-    nextVersion: 'patch',
-    execCommand: jest.fn()
-  };
+  describe('without preid', () => {
+    const options = {
+      nextVersion: 'patch',
+      preid: undefined,
+      execCommand: jest.fn()
+    };
 
-  it('publishes new version', () => {
-    expect(() => publish(options)).not.toThrow();
-    expect(options.execCommand.mock.calls[0][0]).toBe('npm version patch');
-    expect(options.execCommand.mock.calls[1][0]).toBe('npm publish');
+    it('publishes new version without a prerelease tag', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe('npm version patch');
+      expect(options.execCommand.mock.calls[1][0]).toBe('npm publish');
+    });
+  });
+
+  describe('with preid', () => {
+    const options = {
+      nextVersion: 'major',
+      preid: 'alpha',
+      execCommand: jest.fn()
+    };
+
+    it('publishes new version with a prerelease tag', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe(
+        'npm version major --preid=alpha'
+      );
+      expect(options.execCommand.mock.calls[1][0]).toBe('npm publish');
+    });
   });
 });

--- a/src/client/npm.spec.js
+++ b/src/client/npm.spec.js
@@ -2,11 +2,12 @@ const { publish } = require('./npm');
 
 describe('publish', () => {
   const options = {
+    nextVersion: 'patch',
     execCommand: jest.fn()
   };
 
   it('publishes new version', () => {
-    expect(() => publish('patch', options)).not.toThrow();
+    expect(() => publish(options)).not.toThrow();
     expect(options.execCommand.mock.calls[0][0]).toBe('npm version patch');
     expect(options.execCommand.mock.calls[1][0]).toBe('npm publish');
   });

--- a/src/client/yarn.js
+++ b/src/client/yarn.js
@@ -1,4 +1,4 @@
-const publish = (nextVersion, { execCommand }) => {
+const publish = ({ nextVersion, execCommand }) => {
   execCommand(`yarn publish --new-version ${nextVersion}`);
 };
 

--- a/src/client/yarn.spec.js
+++ b/src/client/yarn.spec.js
@@ -2,11 +2,12 @@ const { publish } = require('./yarn');
 
 describe('publish', () => {
   const options = {
+    nextVersion: 'patch',
     execCommand: jest.fn()
   };
 
   it('publishes new version', () => {
-    expect(() => publish('patch', options)).not.toThrow();
+    expect(() => publish(options)).not.toThrow();
     expect(options.execCommand.mock.calls[0][0]).toBe(
       'yarn publish --new-version patch'
     );

--- a/src/client/yarn.spec.js
+++ b/src/client/yarn.spec.js
@@ -1,15 +1,33 @@
 const { publish } = require('./yarn');
 
 describe('publish', () => {
-  const options = {
-    nextVersion: 'patch',
-    execCommand: jest.fn()
-  };
+  describe('without preid', () => {
+    const options = {
+      nextVersion: 'patch',
+      preid: undefined,
+      execCommand: jest.fn()
+    };
 
-  it('publishes new version', () => {
-    expect(() => publish(options)).not.toThrow();
-    expect(options.execCommand.mock.calls[0][0]).toBe(
-      'yarn publish --new-version patch'
-    );
+    it('publishes new version without a prerelease id', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe(
+        'yarn publish --new-version patch'
+      );
+    });
+  });
+
+  describe('with preid', () => {
+    const options = {
+      nextVersion: 'major',
+      preid: 'alpha',
+      execCommand: jest.fn()
+    };
+
+    it('publishes new version without a prerelease id', () => {
+      expect(() => publish(options)).not.toThrow();
+      expect(options.execCommand.mock.calls[0][0]).toBe(
+        'yarn publish --new-version major'
+      );
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 const {
   loadReleaseConfig,
   execCommands,
-  validVersion,
   currentCommitId,
   rollbackCommit
 } = require('./utils');
 const command = require('./utils/command');
 
-const release = ({ env, nextVersion }) => {
+const release = (options) => {
+  const { env } = options;
   const config = loadReleaseConfig(env);
   const publishClient = require(`./client/${env.publishClient}.js`);
 
@@ -22,10 +22,9 @@ const release = ({ env, nextVersion }) => {
     if (config.publish) {
       execCommands(config.publish);
     } else {
-      publishClient.publish(nextVersion, {
-        validVersion,
-        execCommand: command.exec
-      });
+      publishClient.publish(Object.assign(
+        {}, options, { execCommand: command.exec }
+      ));
     }
 
     execCommands(config.after_publish);

--- a/src/utils/validations/index.js
+++ b/src/utils/validations/index.js
@@ -19,15 +19,6 @@ const validateTestRunner = testRunner => {
   }
 };
 
-const validateVersion = (version, env) => {
-  if (env.publishClient === 'lerna') return;
-  if (VERSIONS.includes(version)) return;
-
-  throw new Error(
-    'Version argument is not supported, use either `major`, `minor` or `patch`'
-  );
-};
-
 const validateLerna = () => {
   if (fs.existsSync(LERNA_JSON_PATH)) return;
 
@@ -41,7 +32,6 @@ const isBuildDefined = pkg => pkg.scripts && pkg.scripts.build;
 module.exports = {
   validatePkgRoot,
   validateTestRunner,
-  validateVersion,
   validateLerna,
   isBuildDefined
 };

--- a/src/utils/validations/index.spec.js
+++ b/src/utils/validations/index.spec.js
@@ -1,7 +1,6 @@
 const {
   validatePkgRoot,
   validateTestRunner,
-  validateVersion,
   validateLerna,
   isBuildDefined
 } = require('./');
@@ -50,37 +49,6 @@ describe('validateTestRunner', () => {
 
     it('throws an error', () => {
       expect(() => validateTestRunner(testRunner)).toThrow();
-    });
-  });
-});
-
-describe('validateVersion', () => {
-  describe('when lerna is the detected publish client', () => {
-    const env = { publishClient: 'lerna' };
-    const version = null;
-
-    it('does not throw an error', () => {
-      expect(() => validateVersion(version, env)).not.toThrow();
-    });
-  });
-
-  describe('when lerna is not the detected publish client', () => {
-    const env = { publishClient: 'yarn' };
-
-    describe('and version is valid', () => {
-      const version = 'patch';
-
-      it('does not throw an error', () => {
-        expect(() => validateVersion(version, env)).not.toThrow();
-      });
-    });
-
-    describe('and version is not valid', () => {
-      const version = 'prepatch';
-
-      it('throws an error', () => {
-        expect(() => validateVersion(version, env)).toThrow();
-      });
     });
   });
 });


### PR DESCRIPTION
Addresses #25. This PR removes the in-house validation of the version option. Instead, it lets the npm client in use to take care of it. In the second step, it also adds a `prerelease-id` option.

### To do:
- [ ] Reflect changes in the documentation