### PR TITLE
Implement a setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,30 +16,35 @@ This is a configurable release automation tool for node packages inspired by [cr
 # Getting started
 ## 1. Install the package:
 
-```
+```sh
 npm install node-publisher --save-dev
 ```
 
 or
 
-```
+```sh
 yarn add --dev node-publisher
 ```
 
-## 2. Add following scripts to `package.json`
-```js
-// package.json
-// make sure the `travis` command exits with a status that can be read from the terminal with $?
+## 2. Setup
 
-{
-  ...,
-  "scripts": {
-    "travis": "your linting/testing/etc. command here",
-    "release": "node-publisher release",
-  },
-  ...
-}
+Run the setup script:
+
+```sh
+npx node-publisher setup
 ```
+
+The script will search for unmet requirements in your package and attempt to fix them automatically. In case there is more info needed, it will ask some questions about your project.
+
+Possible questions:
+
+- `Which branch is your default one?` It is assumed that one would like to release from the main branch. Of course, it might not be your case, so pick the branch that you would like to release from.
+- In case you don't have NVM installed and a .nvmrc file is missing, it might ask you `whether to generate it anyway`.
+- Before the tool generates the .nvmrc file, it will ask you the `Node version you would like it to use` there. The default version is your current Node version.
+- If a `build` script is missing, it will ask whether it should generate an empty one for you.
+- If a `ci` script is missing, the same question will be asked.
+
+For more info, read the [Prerequisites section](#prerequisites).
 
 # Usage
 

--- a/bin/node-publisher
+++ b/bin/node-publisher
@@ -6,6 +6,7 @@ const pkg = require('../package.json');
 program
   .version(pkg.version, '-v, --version')
   .description('A configurable release automation tool for node packages inspired by Travis CI.')
+  .command('setup', 'integrates node-publisher by setting up the release script in package.json')
   .command('eject', 'makes the release process fully configurable by placing the default configuration as a `.release.yml` file in the root directory of the package')
   .command('release [version]', 'releases the specified version of the package', {isDefault: true})
   .parse(process.argv);

--- a/bin/node-publisher-setup
+++ b/bin/node-publisher-setup
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const program = require('commander');
+const {
+  searchForIssues,
+  askSetupQuestions,
+  run
+} = require('../src/setup');
+
+program
+  .description('Integrates node-publisher by setting up the release script in `package.json`.')
+  .parse(process.argv);
+
+(async () => {
+  try {  
+    const issues = searchForIssues();
+    const answers = askSetupQuestions(issues);
+
+    run(issues, answers);
+
+    console.log('🤘 All set up. Now go and rock it!');
+  } catch (e) {
+    console.error(`ERROR: ${e.message}`);
+    process.exit(1);
+  }
+})();

--- a/bin/node-publisher-setup
+++ b/bin/node-publisher-setup
@@ -12,9 +12,9 @@ program
   .parse(process.argv);
 
 (async () => {
-  try {  
+  try {
     const issues = searchForIssues();
-    const answers = askSetupQuestions(issues);
+    const answers = await askSetupQuestions(issues);
 
     run(issues, answers);
 

--- a/bin/node-publisher-setup
+++ b/bin/node-publisher-setup
@@ -16,9 +16,9 @@ program
     const issues = searchForIssues();
     const answers = await askSetupQuestions(issues);
 
-    run(issues, answers);
-
-    console.log('🤘 All set up. Now go and rock it!');
+    if (run(issues, answers)) {
+      console.log('🤘 All set up. Now go and rock it!');
+    }
   } catch (e) {
     console.error(`ERROR: ${e.message}`);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "dependencies": {
     "check-node-version": "3.2.0",
     "commander": "2.15.1",
+    "inquirer": "6.2.1",
     "js-yaml": "3.12.0",
-    "offline-github-changelog": "1.2.0"
+    "offline-github-changelog": "1.2.0",
+    "semver": "5.6.0"
   },
   "devDependencies": {
     "babel-eslint": "8.2.3",

--- a/src/setup/constants.js
+++ b/src/setup/constants.js
@@ -1,0 +1,42 @@
+const names = {
+  WITHOUT_GIT: 'without_git',
+  DEFAULT_BRANCH: 'default_branch',
+  GENERATE_NVMRC: 'generate_nvmrc',
+  NVM_VERSION: 'nvm_version',
+  BUILD_MISSING: 'build_missing',
+  CI_MISSING: 'ci_missing'
+};
+
+const messages = {
+  DEFAULT_BRANCH: 'Which of the following branches is your default one?',
+  GENERATE_NVMRC:
+    'Your system does not have NVM installed. Would you like me to generate a .nvmrc file anyway?',
+  NVM_VERSION: 'What version of Node would you like your package to depend on?',
+  BUILD_MISSING:
+    'Your package does not have a `build` script defined.\nWould you like me to generate an empty `build` script for you?',
+  CI_MISSING:
+    'Your package does not have a `ci` nor a `travis` script defined.\nWould you like me to generate an empty `ci` script for you?'
+};
+
+const warnings = {
+  NVM_NOT_INSTALLED: `Your system does not have NVM installed. Install NVM (https://github.com/creationix/nvm#installation) or eject by running \`npx node-publisher eject\` and \
+customize the release process to skip checking the Node version before release.`,
+  CI_MISSING: `An empty CI script under the key \`ci\` has been generated for you in your package.json. It is strongly recommended to define your testing procedure there. \
+Make sure you procedure exits with a status that can be read from the terminal with \`$?\``,
+  CUSTOM_CONFIG:
+    'Your project setup requires a customized release process. Please, run `npx node-publisher eject` and customize your release.'
+};
+
+const errors = {
+  WITHOUT_GIT:
+    'This is not a Git repository. Run `git init` before running this setup.',
+  NVM_VERSION:
+    'The specified version is not a valid semver. Examples of valid semver: 1.2.3, 42.6.7.9.3-alpha, etc.'
+};
+
+module.exports = {
+  names,
+  messages,
+  warnings,
+  errors
+};

--- a/src/setup/constants.js
+++ b/src/setup/constants.js
@@ -21,6 +21,7 @@ const messages = {
 const warnings = {
   NVM_NOT_INSTALLED: `Your system does not have NVM installed. Install NVM (https://github.com/creationix/nvm#installation) or eject by running \`npx node-publisher eject\` and \
 customize the release process to skip checking the Node version before release.`,
+  BUILD_MISSING: `An empty build script has been set up for you under the key \`build\`. Make sure to set up your build procedure there.`,
   CI_MISSING: `An empty CI script under the key \`ci\` has been generated for you in your package.json. It is strongly recommended to define your testing procedure there. \
 Make sure your procedure exits with a status that can be read from the terminal with $?`,
   CUSTOM_CONFIG: `Your project setup most probably requires a customized release process. No changes have been made to your project setup.\n\

--- a/src/setup/constants.js
+++ b/src/setup/constants.js
@@ -22,9 +22,10 @@ const warnings = {
   NVM_NOT_INSTALLED: `Your system does not have NVM installed. Install NVM (https://github.com/creationix/nvm#installation) or eject by running \`npx node-publisher eject\` and \
 customize the release process to skip checking the Node version before release.`,
   CI_MISSING: `An empty CI script under the key \`ci\` has been generated for you in your package.json. It is strongly recommended to define your testing procedure there. \
-Make sure you procedure exits with a status that can be read from the terminal with \`$?\``,
-  CUSTOM_CONFIG:
-    'Your project setup requires a customized release process. Please, run `npx node-publisher eject` and customize your release.'
+Make sure your procedure exits with a status that can be read from the terminal with $?`,
+  CUSTOM_CONFIG: `Your project setup most probably requires a customized release process. No changes have been made to your project setup.\n\
+To customize your release, run \`npx node-publisher eject\`.\n\
+For more info, check out the documentation: https://github.com/zendesk/node-publisher#customize-the-release-process.`
 };
 
 const errors = {

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -14,6 +14,7 @@ const {
   errors
 } = require('./constants');
 const { updatePackageJson, generateNvmrcFile, warn } = require('./tasks');
+const { versionTransformer } = require('../utils');
 const {
   isGitProject,
   isNvmInstalled,
@@ -38,9 +39,6 @@ const gitBranches = () => {
 
 const validateVersion = version =>
   semver.valid(version) ? true : errors.NVM_VERSION;
-
-const versionTransformer = (version, _answers, flags) =>
-  flags.isFinal && version[0] !== 'v' ? `v${version}` : version;
 
 const searchForIssues = () => {
   const issues = {};
@@ -125,7 +123,6 @@ const run = (issues, answers) => {
 module.exports = {
   gitBranches,
   validateVersion,
-  versionTransformer,
   searchForIssues,
   askSetupQuestions,
   run

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -108,6 +108,10 @@ const run = (issues, answers) => {
 
   updatePackageJson(answers);
 
+  if (answers[BUILD_MISSING] === true) {
+    warn(warnings.BUILD_MISSING);
+  }
+
   if (issues[CI_MISSING] === true) {
     warn(warnings.CI_MISSING);
   }

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -1,0 +1,133 @@
+const childProcess = require('child_process');
+const semver = require('semver');
+const inquirer = require('inquirer');
+const { generateQuestions, askNvmVersion } = require('./questions');
+const {
+  names: {
+    WITHOUT_GIT,
+    DEFAULT_BRANCH,
+    GENERATE_NVMRC,
+    NVM_VERSION,
+    BUILD_MISSING,
+    CI_MISSING
+  },
+  warnings,
+  errors
+} = require('./constants');
+const { updatePackageJson, generateNvmrcFile, warn } = require('./tasks');
+const {
+  isGitProject,
+  isNvmInstalled,
+  nvmrcExists,
+  hasBuildScript,
+  hasCiScript
+} = require('../utils/validations');
+
+const gitBranches = () => {
+  const rawBranches = childProcess.execSync('git branch').toString();
+  const branchesRegex = /^\s*(?:\* )?(.+)/gm;
+  const branches = [];
+
+  let match = branchesRegex.exec(rawBranches);
+  while (match !== null) {
+    branches.push(match[1].trim());
+    match = branchesRegex.exec(rawBranches);
+  }
+
+  return branches;
+};
+
+const validateVersion = version =>
+  semver.valid(version) ? true : errors.NVM_VERSION;
+
+const versionTransformer = (version, _answers, flags) =>
+  flags.isFinal && version[0] !== 'v' ? `v${version}` : version;
+
+const searchForIssues = () => {
+  const issues = {};
+
+  if (isGitProject()) {
+    issues[DEFAULT_BRANCH] = {
+      choices: gitBranches()
+    };
+  } else {
+    throw new Error(errors[WITHOUT_GIT]);
+  }
+
+  const nvmInstalled = isNvmInstalled();
+  if (!nvmInstalled) {
+    issues[GENERATE_NVMRC] = true;
+  }
+
+  const nvmrcFileExists = nvmrcExists();
+  if (!nvmrcFileExists) {
+    issues[NVM_VERSION] = {
+      default: childProcess
+        .execSync('node -v')
+        .toString()
+        .trim(),
+      validate: validateVersion,
+      transformer: versionTransformer
+    };
+  }
+
+  if (!hasBuildScript()) {
+    issues[BUILD_MISSING] = true;
+  }
+
+  if (!hasCiScript()) {
+    issues[CI_MISSING] = true;
+  }
+
+  issues.nvmInstalled = () => nvmInstalled;
+  issues.nvmrcExists = () => nvmrcFileExists;
+
+  return issues;
+};
+
+async function askSetupQuestions(issues) {
+  let questions = generateQuestions(issues);
+  const answers = await inquirer.prompt(questions);
+
+  if (!issues.nvmrcExists()) {
+    if (
+      issues.nvmInstalled() ||
+      (!issues.nvmInstalled() && answers[GENERATE_NVMRC] === true)
+    ) {
+      questions = [askNvmVersion(issues[NVM_VERSION])];
+      const secondRoundAnswers = await inquirer.prompt(questions);
+
+      answers[NVM_VERSION] = secondRoundAnswers[NVM_VERSION];
+    }
+  }
+
+  return answers;
+}
+
+const run = (issues, answers) => {
+  if (answers[GENERATE_NVMRC] === false || answers[CI_MISSING] === false) {
+    return warn(warnings.CUSTOM_CONFIG);
+  }
+
+  updatePackageJson(answers);
+
+  if (issues[CI_MISSING] === true) {
+    warn(warnings.CI_MISSING);
+  }
+
+  if (!issues.nvmrcExists()) {
+    generateNvmrcFile(answers[NVM_VERSION]);
+    if (!issues.nvmInstalled()) {
+      warn(warnings.NVM_NOT_INSTALLED);
+    }
+  }
+};
+
+module.exports = {
+  gitBranches,
+  validateVersion,
+  versionTransformer,
+  searchForIssues,
+  askSetupQuestions,
+  run
+};

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -86,7 +86,7 @@ async function askSetupQuestions(issues) {
   let questions = generateQuestions(issues);
   const answers = await inquirer.prompt(questions);
 
-  if (!issues.nvmrcExists()) {
+  if (!issues.nvmrcExists() && answers[CI_MISSING] === true) {
     if (
       issues.nvmInstalled() ||
       (!issues.nvmInstalled() && answers[GENERATE_NVMRC] === true)

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -101,9 +101,13 @@ async function askSetupQuestions(issues) {
   return answers;
 }
 
+const requiresCustomConfig = answers =>
+  answers[GENERATE_NVMRC] === false || answers[CI_MISSING] === false;
+
 const run = (issues, answers) => {
-  if (answers[GENERATE_NVMRC] === false || answers[CI_MISSING] === false) {
-    return warn(warnings.CUSTOM_CONFIG);
+  if (requiresCustomConfig(answers)) {
+    warn(warnings.CUSTOM_CONFIG);
+    return false;
   }
 
   updatePackageJson(answers);
@@ -122,6 +126,8 @@ const run = (issues, answers) => {
       warn(warnings.NVM_NOT_INSTALLED);
     }
   }
+
+  return true;
 };
 
 module.exports = {

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -4,7 +4,6 @@ const inquirer = require('inquirer');
 const { generateQuestions, askNvmVersion } = require('./questions');
 const {
   names: {
-    WITHOUT_GIT,
     DEFAULT_BRANCH,
     GENERATE_NVMRC,
     NVM_VERSION,
@@ -51,7 +50,7 @@ const searchForIssues = () => {
       choices: gitBranches()
     };
   } else {
-    throw new Error(errors[WITHOUT_GIT]);
+    throw new Error(errors.WITHOUT_GIT);
   }
 
   const nvmInstalled = isNvmInstalled();

--- a/src/setup/index.spec.js
+++ b/src/setup/index.spec.js
@@ -1,0 +1,414 @@
+const inquirer = require('inquirer');
+const validations = require('../utils/validations');
+const { names, warnings } = require('./constants');
+const questions = require('./questions');
+const tasks = require('./tasks');
+const {
+  gitBranches,
+  validateVersion,
+  versionTransformer,
+  searchForIssues,
+  askSetupQuestions,
+  run
+} = require('./');
+
+jest.mock('child_process');
+jest.mock('inquirer');
+jest.mock('../utils/validations');
+jest.mock('./questions');
+jest.mock('./tasks');
+
+require('child_process').__permitCommands(['git', 'node']);
+
+describe('gitBranches', () => {
+  describe('when the first branch is the current branch', () => {
+    const rawBranches = `* abc-branch-xyz
+    master
+    my-branch-123`;
+
+    it('returns the git branches correctly', () => {
+      require('child_process').__setReturnValues({
+        'git branch': rawBranches
+      });
+
+      expect(gitBranches()).toEqual([
+        'abc-branch-xyz',
+        'master',
+        'my-branch-123'
+      ]);
+    });
+  });
+
+  describe('when the second branch is the current branch', () => {
+    const rawBranches = `abc-branch-xyz
+    * master
+    my-branch-123`;
+
+    it('returns the git branches correctly', () => {
+      require('child_process').__setReturnValues({
+        'git branch': rawBranches
+      });
+
+      expect(gitBranches()).toEqual([
+        'abc-branch-xyz',
+        'master',
+        'my-branch-123'
+      ]);
+    });
+  });
+});
+
+describe('validateVersion', () => {
+  describe('when version is valid', () => {
+    it('returns true', () => {
+      expect(validateVersion('9.11.1')).toBe(true);
+    });
+  });
+
+  describe('when version is invalid', () => {
+    it('returns an error message', () => {
+      expect(validateVersion('a.b.c')).toBe(
+        'The specified version is not a valid semver. Examples of valid semver: 1.2.3, 42.6.7.9.3-alpha, etc.'
+      );
+    });
+  });
+});
+
+describe('versionTransformer', () => {
+  describe('when isFinal flag is true', () => {
+    const isFinal = true;
+
+    it('returns the version with the "v" prefix', () => {
+      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('v9.11.1');
+      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
+    });
+  });
+
+  describe('when isFinal flag is false', () => {
+    const isFinal = false;
+
+    it('returns the version as input by the user', () => {
+      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('9.11.1');
+      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
+    });
+  });
+});
+
+describe('searchForIssues', () => {
+  beforeAll(() => {
+    require('child_process').__setReturnValues({
+      'git branch': 'master',
+      'node -v': 'v9.11.1\n'
+    });
+  });
+
+  beforeEach(() => {
+    validations.isGitProject.mockReturnValue(true);
+    validations.isNvmInstalled.mockReturnValue(true);
+    validations.nvmrcExists.mockReturnValue(true);
+    validations.hasBuildScript.mockReturnValue(true);
+    validations.hasCiScript.mockReturnValue(true);
+  });
+
+  describe('when project uses git', () => {
+    it('contains the default branch issue', () => {
+      expect(searchForIssues()).toMatchObject({
+        [names.DEFAULT_BRANCH]: { choices: ['master'] }
+      });
+    });
+  });
+
+  describe('when project does not use git', () => {
+    it('throws', () => {
+      validations.isGitProject.mockReturnValue(false);
+
+      expect(searchForIssues).toThrow();
+    });
+  });
+
+  describe('when NVM is installed', () => {
+    it('does not contain the NVM missing issue', () => {
+      expect(searchForIssues()).not.toMatchObject({
+        [names.GENERATE_NVMRC]: true
+      });
+    });
+  });
+
+  describe('when NVM is not installed', () => {
+    it('contains the NVM missing issue', () => {
+      validations.isNvmInstalled.mockReturnValue(false);
+
+      expect(searchForIssues()).toMatchObject({
+        [names.GENERATE_NVMRC]: true
+      });
+    });
+  });
+
+  describe('when the .nvmrc file exists', () => {
+    it('does not contain the NVM version issue', () => {
+      expect(searchForIssues()).not.toMatchObject({
+        [names.NVM_VERSION]: {
+          default: 'v9.11.1',
+          validate: validateVersion,
+          transformer: versionTransformer
+        }
+      });
+    });
+  });
+
+  describe('when the .nvmrc file does not exist', () => {
+    it('contains the NVM version issue', () => {
+      validations.nvmrcExists.mockReturnValue(false);
+
+      expect(searchForIssues()).toMatchObject({
+        [names.NVM_VERSION]: {
+          default: 'v9.11.1',
+          validate: validateVersion,
+          transformer: versionTransformer
+        }
+      });
+    });
+  });
+
+  describe('when the package.json contains a build script', () => {
+    it('does not contain the build missing issue', () => {
+      expect(searchForIssues()).not.toMatchObject({
+        [names.BUILD_MISSING]: true
+      });
+    });
+  });
+
+  describe('when the package.json does not contain a build script', () => {
+    it('contains the build missing issue', () => {
+      validations.hasBuildScript.mockReturnValue(false);
+
+      expect(searchForIssues()).toMatchObject({
+        [names.BUILD_MISSING]: true
+      });
+    });
+  });
+
+  describe('when the package.json contains a valid test runner script', () => {
+    it('does not contain the ci missing issue', () => {
+      expect(searchForIssues()).not.toMatchObject({
+        [names.CI_MISSING]: true
+      });
+    });
+  });
+
+  describe('when the package.json does not contain a valid test runner script', () => {
+    it('contains the ci missing issue', () => {
+      validations.hasCiScript.mockReturnValue(false);
+
+      expect(searchForIssues()).toMatchObject({
+        [names.CI_MISSING]: true
+      });
+    });
+  });
+});
+
+describe('askSetupQuestions', () => {
+  let issues;
+
+  beforeAll(() => {
+    questions.generateQuestions.mockReturnValue([]);
+    questions.askNvmVersion.mockReturnValue([]);
+  });
+
+  afterEach(() => inquirer.prompt.mockClear());
+
+  describe('when .nvmrc file exists', () => {
+    it('skips the second round of questioning', async () => {
+      await askSetupQuestions({
+        nvmrcExists: () => true
+      });
+
+      expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when .nvmrc file does not exist', () => {
+    beforeEach(() => {
+      issues = {
+        nvmrcExists: () => false
+      };
+    });
+
+    describe('and NVM is installed', () => {
+      it('proceeds with the second round of questioning', async () => {
+        inquirer.prompt.mockImplementation(async () => ({
+          [names.NVM_VERSION]: '9.11.1'
+        }));
+
+        await askSetupQuestions(
+          Object.assign(issues, {
+            nvmInstalled: () => true
+          })
+        );
+
+        expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('and NVM is not installed', () => {
+      beforeEach(() => {
+        issues = Object.assign(issues, {
+          nvmInstalled: () => false
+        });
+      });
+
+      describe('but the user wants a .nvmrc file anyway', () => {
+        it('proceeds with the second round of questioning', async () => {
+          inquirer.prompt
+            .mockImplementationOnce(async () => ({
+              [names.GENERATE_NVMRC]: true
+            }))
+            .mockImplementationOnce(async () => ({
+              [names.NVM_VERSION]: '9.11.1'
+            }));
+
+          await askSetupQuestions(issues);
+
+          expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe('and the user does not want a .nvmrc file', () => {
+        it('skips the second round of questioning', async () => {
+          inquirer.prompt.mockImplementation(async () => ({
+            [names.GENERATE_NVMRC]: false
+          }));
+
+          await askSetupQuestions(issues);
+
+          expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+});
+
+describe('run', () => {
+  let issues, answers;
+
+  beforeEach(() => {
+    issues = {
+      nvmInstalled: () => true,
+      nvmrcExists: () => true
+    };
+
+    answers = {
+      [names.NVM_VERSION]: '9.11.1',
+      [names.GENERATE_NVMRC]: true
+    };
+  });
+
+  afterEach(() => {
+    tasks.updatePackageJson.mockClear();
+    tasks.generateNvmrcFile.mockClear();
+    tasks.warn.mockClear();
+  });
+
+  it('updates the package.json file', () => {
+    run(issues, answers);
+
+    expect(tasks.updatePackageJson).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when a CI script is missing', () => {
+    describe('and a user wants to generate one', () => {
+      it('warns the user to define her testing procedure under the generated CI script', () => {
+        issues = Object.assign(issues, { [names.CI_MISSING]: true });
+
+        run(issues, answers);
+
+        expect(tasks.warn).toHaveBeenCalledTimes(1);
+        expect(tasks.warn).toHaveBeenCalledWith(warnings.CI_MISSING);
+      });
+    });
+
+    describe('and a user does not want to generate one', () => {
+      beforeEach(() => {
+        answers = { [names.CI_MISSING]: false };
+        run(issues, answers);
+      });
+
+      it('warns the user to use a custom release process', () => {
+        expect(tasks.warn).toHaveBeenCalledTimes(1);
+        expect(tasks.warn).toHaveBeenCalledWith(warnings.CUSTOM_CONFIG);
+      });
+
+      it('returns', () => {
+        expect(tasks.updatePackageJson).not.toHaveBeenCalled();
+        expect(tasks.generateNvmrcFile).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when .nvmrc exists', () => {
+    it('skips any further tasks', () => {
+      run(issues, answers);
+
+      expect(tasks.generateNvmrcFile).not.toHaveBeenCalled();
+      expect(tasks.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when .nvmrc does not exist', () => {
+    beforeEach(() => {
+      issues = Object.assign(issues, {
+        nvmrcExists: () => false
+      });
+    });
+
+    describe('and NVM is installed', () => {
+      beforeEach(() => run(issues, answers));
+
+      it('generates a .nvmrc file', () => {
+        expect(tasks.generateNvmrcFile).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not warn the user to install NVM', () => {
+        expect(tasks.warn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and NVM is not installed', () => {
+      beforeEach(() => {
+        issues = Object.assign(issues, {
+          nvmInstalled: () => false
+        });
+      });
+
+      describe('but the user wants a .nvmrc file anyway', () => {
+        beforeEach(() => run(issues, answers));
+
+        it('generates a .nvmrc file', () => {
+          expect(tasks.generateNvmrcFile).toHaveBeenCalledTimes(1);
+        });
+
+        it('warns the user to install NVM', () => {
+          expect(tasks.warn).toHaveBeenCalledTimes(1);
+          expect(tasks.warn).toHaveBeenCalledWith(warnings.NVM_NOT_INSTALLED);
+        });
+      });
+
+      describe('and the user does not want a .nvmrc file', () => {
+        beforeEach(() => {
+          answers = { [names.GENERATE_NVMRC]: false };
+          run(issues, answers);
+        });
+
+        it('warns the user to use a custom release process', () => {
+          expect(tasks.warn).toHaveBeenCalledTimes(1);
+          expect(tasks.warn).toHaveBeenCalledWith(warnings.CUSTOM_CONFIG);
+        });
+
+        it('returns', () => {
+          expect(tasks.updatePackageJson).not.toHaveBeenCalled();
+          expect(tasks.generateNvmrcFile).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/setup/index.spec.js
+++ b/src/setup/index.spec.js
@@ -3,10 +3,10 @@ const validations = require('../utils/validations');
 const { names, warnings } = require('./constants');
 const questions = require('./questions');
 const tasks = require('./tasks');
+const { versionTransformer } = require('../utils');
 const {
   gitBranches,
   validateVersion,
-  versionTransformer,
   searchForIssues,
   askSetupQuestions,
   run
@@ -70,26 +70,6 @@ describe('validateVersion', () => {
       expect(validateVersion('a.b.c')).toBe(
         'The specified version is not a valid semver. Examples of valid semver: 1.2.3, 42.6.7.9.3-alpha, etc.'
       );
-    });
-  });
-});
-
-describe('versionTransformer', () => {
-  describe('when isFinal flag is true', () => {
-    const isFinal = true;
-
-    it('returns the version with the "v" prefix', () => {
-      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('v9.11.1');
-      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
-    });
-  });
-
-  describe('when isFinal flag is false', () => {
-    const isFinal = false;
-
-    it('returns the version as input by the user', () => {
-      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('9.11.1');
-      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
     });
   });
 });

--- a/src/setup/index.spec.js
+++ b/src/setup/index.spec.js
@@ -214,10 +214,25 @@ describe('askSetupQuestions', () => {
       };
     });
 
+    describe('and the user does not want a CI script to be generated', () => {
+      it('skips the second round of questioning', async () => {
+        inquirer.prompt.mockImplementation(async () => ({
+          [names.CI_MISSING]: false
+        }));
+
+        await askSetupQuestions({
+          nvmrcExists: () => true
+        });
+
+        expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('and NVM is installed', () => {
       it('proceeds with the second round of questioning', async () => {
         inquirer.prompt.mockImplementation(async () => ({
-          [names.NVM_VERSION]: '9.11.1'
+          [names.NVM_VERSION]: '9.11.1',
+          [names.CI_MISSING]: true
         }));
 
         await askSetupQuestions(
@@ -241,7 +256,8 @@ describe('askSetupQuestions', () => {
         it('proceeds with the second round of questioning', async () => {
           inquirer.prompt
             .mockImplementationOnce(async () => ({
-              [names.GENERATE_NVMRC]: true
+              [names.GENERATE_NVMRC]: true,
+              [names.CI_MISSING]: true
             }))
             .mockImplementationOnce(async () => ({
               [names.NVM_VERSION]: '9.11.1'
@@ -256,7 +272,8 @@ describe('askSetupQuestions', () => {
       describe('and the user does not want a .nvmrc file', () => {
         it('skips the second round of questioning', async () => {
           inquirer.prompt.mockImplementation(async () => ({
-            [names.GENERATE_NVMRC]: false
+            [names.GENERATE_NVMRC]: false,
+            [names.CI_MISSING]: true
           }));
 
           await askSetupQuestions(issues);

--- a/src/setup/questions/index.js
+++ b/src/setup/questions/index.js
@@ -1,0 +1,41 @@
+const { names, messages } = require('../constants');
+
+const generateQuestions = issues =>
+  [
+    {
+      type: 'list',
+      name: names.DEFAULT_BRANCH,
+      message: messages.DEFAULT_BRANCH,
+      choices: issues[names.DEFAULT_BRANCH].choices
+    },
+    !issues.nvmInstalled() &&
+      !issues.nvmrcExists() && {
+        type: 'confirm',
+        name: names.GENERATE_NVMRC,
+        message: messages.GENERATE_NVMRC
+      },
+    issues[names.BUILD_MISSING] && {
+      type: 'confirm',
+      name: names.BUILD_MISSING,
+      message: messages.BUILD_MISSING
+    },
+    issues[names.CI_MISSING] && {
+      type: 'confirm',
+      name: names.CI_MISSING,
+      message: messages.CI_MISSING
+    }
+  ].filter(opt => opt);
+
+const askNvmVersion = version => ({
+  type: 'input',
+  name: names.NVM_VERSION,
+  message: messages.NVM_VERSION,
+  default: version.default,
+  validate: version.validate,
+  transformer: version.transformer
+});
+
+module.exports = {
+  generateQuestions,
+  askNvmVersion
+};

--- a/src/setup/questions/index.spec.js
+++ b/src/setup/questions/index.spec.js
@@ -1,0 +1,116 @@
+const { generateQuestions, askNvmVersion } = require('./');
+const { names, messages } = require('../constants');
+
+describe('generateQuestions', () => {
+  const baseIssues = {
+    [names.DEFAULT_BRANCH]: {
+      choices: ['master', 'my-branch']
+    },
+    nvmInstalled: () => true,
+    nvmrcExists: () => true
+  };
+
+  const baseQuestions = [
+    {
+      type: 'list',
+      name: names.DEFAULT_BRANCH,
+      message: messages.DEFAULT_BRANCH,
+      choices: ['master', 'my-branch']
+    }
+  ];
+
+  it('returns the expected set of questions', () => {
+    expect(generateQuestions(baseIssues)).toEqual(baseQuestions);
+  });
+
+  describe('when NVM is not installed', () => {
+    describe('and .nvmrc file exists', () => {
+      const issues = Object.assign({}, baseIssues, {
+        nvmInstalled: () => false,
+        nvmrcExists: () => true
+      });
+
+      it('returns the expected set of questions', () => {
+        expect(generateQuestions(issues)).toEqual(baseQuestions);
+      });
+    });
+
+    describe('and .nvmrc file does not exist', () => {
+      const issues = Object.assign({}, baseIssues, {
+        nvmInstalled: () => false,
+        nvmrcExists: () => false
+      });
+
+      it('returns the expected set of questions', () => {
+        expect(generateQuestions(issues)).toEqual(
+          baseQuestions.concat([
+            {
+              type: 'confirm',
+              name: names.GENERATE_NVMRC,
+              message: messages.GENERATE_NVMRC
+            }
+          ])
+        );
+      });
+    });
+  });
+
+  describe('when .nvmrc file is missing', () => {});
+
+  describe('when a build script is missing from the package.json file', () => {
+    it('returns the expected set of questions', () => {
+      const issues = Object.assign({}, baseIssues, {
+        [names.BUILD_MISSING]: true
+      });
+
+      expect(generateQuestions(issues)).toEqual(
+        baseQuestions.concat([
+          {
+            type: 'confirm',
+            name: names.BUILD_MISSING,
+            message: messages.BUILD_MISSING
+          }
+        ])
+      );
+    });
+  });
+
+  describe('when a ci script is missing from the package.json file', () => {
+    it('returns the expected set of questions', () => {
+      const issues = Object.assign({}, baseIssues, {
+        [names.CI_MISSING]: true
+      });
+
+      expect(generateQuestions(issues)).toEqual(
+        baseQuestions.concat([
+          {
+            type: 'confirm',
+            name: names.CI_MISSING,
+            message: messages.CI_MISSING
+          }
+        ])
+      );
+    });
+  });
+});
+
+describe('askNvmVersion', () => {
+  it('returns the expected set of questions', () => {
+    const mockValidate = () => {};
+    const mockTransformer = () => {};
+    const version = {
+      default: 'v9.11.1',
+      validate: mockValidate,
+      transformer: mockTransformer
+    };
+
+    expect(askNvmVersion(version)).toEqual({
+      type: 'input',
+      name: names.NVM_VERSION,
+      message: messages.NVM_VERSION,
+      default: 'v9.11.1',
+      validate: mockValidate,
+      transformer: mockTransformer
+    });
+  });
+});

--- a/src/setup/tasks/index.js
+++ b/src/setup/tasks/index.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const { packageJson } = require('../../utils');
+const { PACKAGE_JSON_PATH, NVM_CONFIG_PATH } = require('../../utils/constants');
+const {
+  names: { DEFAULT_BRANCH, BUILD_MISSING, CI_MISSING }
+} = require('../constants');
+const { versionTransformer } = require('../');
+
+const buildScripts = answers => {
+  const defaultBranch = answers[DEFAULT_BRANCH] || 'master';
+  const releaseCommand =
+    defaultBranch === 'master'
+      ? 'node-publisher release'
+      : `node-publisher release --default-branch=${defaultBranch}`;
+
+  const scripts = { release: releaseCommand };
+  if (answers[BUILD_MISSING]) {
+    scripts.build = '';
+  }
+  if (answers[CI_MISSING]) {
+    scripts.ci = '';
+  }
+
+  return scripts;
+};
+
+const format = obj => JSON.stringify(obj, null, 2) + '\n';
+
+const updatePackageJson = answers => {
+  const pkg = packageJson();
+  const newScripts = Object.assign({}, pkg.scripts, buildScripts(answers));
+
+  fs.writeFileSync(
+    PACKAGE_JSON_PATH,
+    format(Object.assign({}, pkg, { scripts: newScripts })),
+    'utf-8'
+  );
+};
+
+const generateNvmrcFile = version =>
+  fs.writeFileSync(
+    NVM_CONFIG_PATH,
+    `${versionTransformer(version, {}, { isFinal: true })}\n`,
+    'utf-8'
+  );
+
+const warn = message => console.log(`WARNING: ${message}`);
+
+module.exports = {
+  buildScripts,
+  updatePackageJson,
+  generateNvmrcFile,
+  warn
+};

--- a/src/setup/tasks/index.js
+++ b/src/setup/tasks/index.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
-const { packageJson } = require('../../utils');
+const { packageJson } = require('../../utils/package');
 const { PACKAGE_JSON_PATH, NVM_CONFIG_PATH } = require('../../utils/constants');
 const {
   names: { DEFAULT_BRANCH, BUILD_MISSING, CI_MISSING }
 } = require('../constants');
-const { versionTransformer } = require('../');
+const { versionTransformer } = require('../../utils');
 
 const buildScripts = answers => {
   const defaultBranch = answers[DEFAULT_BRANCH] || 'master';

--- a/src/setup/tasks/index.spec.js
+++ b/src/setup/tasks/index.spec.js
@@ -1,4 +1,4 @@
-const utils = require('../../utils');
+const utils = require('../../utils/package');
 const { NVM_CONFIG_PATH, PACKAGE_JSON_PATH } = require('../../utils/constants');
 const {
   buildScripts,
@@ -8,7 +8,7 @@ const {
 } = require('./');
 
 jest.mock('fs');
-jest.mock('../../utils');
+jest.mock('../../utils/package');
 
 describe('buildScripts', () => {
   describe('when the default branch is not master', () => {

--- a/src/setup/tasks/index.spec.js
+++ b/src/setup/tasks/index.spec.js
@@ -1,0 +1,135 @@
+const utils = require('../../utils');
+const { NVM_CONFIG_PATH, PACKAGE_JSON_PATH } = require('../../utils/constants');
+const {
+  buildScripts,
+  updatePackageJson,
+  generateNvmrcFile,
+  warn
+} = require('./');
+
+jest.mock('fs');
+jest.mock('../../utils');
+
+describe('buildScripts', () => {
+  describe('when the default branch is not master', () => {
+    const answers = { default_branch: 'my-branch' };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release --default-branch=my-branch'
+      });
+    });
+  });
+
+  describe('when the default branch is master', () => {
+    const answers = { default_branch: 'master' };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release'
+      });
+    });
+  });
+
+  describe('when the default branch is not given', () => {
+    const answers = {};
+
+    it('falls back to master branch and returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release'
+      });
+    });
+  });
+
+  describe('when the user wants to generate an empty build script', () => {
+    const answers = { build_missing: true };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release',
+        build: ''
+      });
+    });
+  });
+
+  describe('when the user does not want to generate an empty build script', () => {
+    const answers = { build_missing: false };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release'
+      });
+    });
+  });
+
+  describe('when the user wants to generate an empty ci script', () => {
+    const answers = { ci_missing: true };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release',
+        ci: ''
+      });
+    });
+  });
+
+  describe('when the user does not want to generate an empty ci script', () => {
+    const answers = { ci_missing: false };
+
+    it('returns the expected scripts object', () => {
+      expect(buildScripts(answers)).toEqual({
+        release: 'node-publisher release'
+      });
+    });
+  });
+});
+
+describe('updatePackageJson', () => {
+  it('writes to package.json the expected payload', () => {
+    utils.packageJson.mockReturnValue({ scripts: {} });
+    const mockWriteFileSync = (require('fs').writeFileSync = jest.fn());
+
+    updatePackageJson({});
+
+    const payload = `{
+  "scripts": {
+    "release": "node-publisher release"
+  }
+}
+`;
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      PACKAGE_JSON_PATH,
+      payload,
+      'utf-8'
+    );
+  });
+});
+
+describe('generateNvmrcFile', () => {
+  it('writes the specified node version to the .nvmrc file', () => {
+    const mockWriteFileSync = (require('fs').writeFileSync = jest.fn());
+
+    generateNvmrcFile('9.11.1');
+
+    const payload = `v9.11.1
+`;
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      NVM_CONFIG_PATH,
+      payload,
+      'utf-8'
+    );
+  });
+});
+
+describe('warn', () => {
+  it('prepends `WARNING: ` to the message nefore console logging it', () => {
+    global.console = { log: jest.fn() };
+
+    warn('nvm not installed');
+
+    expect(console.log).toHaveBeenCalledWith('WARNING: nvm not installed');
+    console.log.mockRestore();
+  });
+});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const os = require('os');
 
 const DEFAULT_TEST_RUNNER = 'travis';
 const VALID_TEST_RUNNERS = [DEFAULT_TEST_RUNNER, 'ci'];
@@ -6,6 +7,13 @@ const DEFAULT_BRANCH = 'master';
 const DEFAULT_CONFIG_PATH = '.release.yml';
 const PACKAGE_JSON_PATH = path.resolve(process.env.PWD, 'package.json');
 const LERNA_JSON_PATH = path.resolve(process.env.PWD, 'lerna.json');
+const DEFAULT_RELEASE_CONFIG_PATH = path.resolve(
+  process.env.PWD,
+  '.release.yml'
+);
+const GIT_PATH = path.resolve(process.env.PWD, '.git');
+const NVM_PATH = path.resolve(os.homedir(), '.nvm');
+const NVM_CONFIG_PATH = path.resolve(process.env.PWD, '.nvmrc');
 
 module.exports = {
   DEFAULT_TEST_RUNNER,
@@ -13,5 +21,9 @@ module.exports = {
   DEFAULT_BRANCH,
   DEFAULT_CONFIG_PATH,
   PACKAGE_JSON_PATH,
-  LERNA_JSON_PATH
+  LERNA_JSON_PATH,
+  DEFAULT_RELEASE_CONFIG_PATH,
+  GIT_PATH,
+  NVM_PATH,
+  NVM_CONFIG_PATH
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const VERSIONS = ['major', 'minor', 'patch'];
 const DEFAULT_TEST_RUNNER = 'travis';
 const VALID_TEST_RUNNERS = [DEFAULT_TEST_RUNNER, 'ci'];
 const DEFAULT_BRANCH = 'master';
@@ -9,7 +8,6 @@ const PACKAGE_JSON_PATH = path.resolve(process.env.PWD, 'package.json');
 const LERNA_JSON_PATH = path.resolve(process.env.PWD, 'lerna.json');
 
 module.exports = {
-  VERSIONS,
   DEFAULT_TEST_RUNNER,
   VALID_TEST_RUNNERS,
   DEFAULT_BRANCH,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,7 +14,7 @@ const {
   validatePkgRoot,
   validateTestRunner,
   validateLerna,
-  isBuildDefined
+  hasBuildScript
 } = require('./validations');
 
 const packageJson = (() => {
@@ -62,7 +62,7 @@ const buildReleaseEnvironment = ({
     branch: branch,
     configPath: configPath,
     testRunner: testRunner,
-    withBuildStep: isBuildDefined(pkg)
+    withBuildStep: hasBuildScript()
   };
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,7 +38,7 @@ const buildReleaseEnvironment = ({
 }) => {
   validatePkgRoot();
 
-  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+  const pkg = packageJson();
   const testRunner =
     VALID_TEST_RUNNERS.find(script => script in pkg.scripts) ||
     DEFAULT_TEST_RUNNER;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,6 +17,20 @@ const {
   isBuildDefined
 } = require('./validations');
 
+const packageJson = (() => {
+  let pkg;
+
+  const readPkg = () => {
+    if (pkg) return pkg;
+
+    pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+
+    return pkg;
+  };
+
+  return readPkg;
+})();
+
 const buildReleaseEnvironment = ({
   branch = DEFAULT_BRANCH,
   configPath = DEFAULT_CONFIG_PATH,
@@ -87,6 +101,7 @@ const currentCommitId = () =>
 const rollbackCommit = commitId => command.exec(`git reset --hard ${commitId}`);
 
 module.exports = {
+  packageJson,
   buildReleaseEnvironment,
   loadReleaseConfig,
   execCommands,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 const command = require('./command');
 const {
-  PACKAGE_JSON_PATH,
   DEFAULT_CONFIG_PATH,
   DEFAULT_BRANCH,
   VALID_TEST_RUNNERS,
@@ -10,26 +9,13 @@ const {
 } = require('./constants');
 const { npmClient, publishClient } = require('./client');
 const { readReleaseConfig, buildReleaseConfig } = require('./config');
+const { packageJson } = require('./package');
 const {
   validatePkgRoot,
   validateTestRunner,
   validateLerna,
   hasBuildScript
 } = require('./validations');
-
-const packageJson = (() => {
-  let pkg;
-
-  const readPkg = () => {
-    if (pkg) return pkg;
-
-    pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
-
-    return pkg;
-  };
-
-  return readPkg;
-})();
 
 const buildReleaseEnvironment = ({
   branch = DEFAULT_BRANCH,
@@ -100,11 +86,14 @@ const currentCommitId = () =>
 
 const rollbackCommit = commitId => command.exec(`git reset --hard ${commitId}`);
 
+const versionTransformer = (version, _answers, flags) =>
+  flags.isFinal && version[0] !== 'v' ? `v${version}` : version;
+
 module.exports = {
-  packageJson,
   buildReleaseEnvironment,
   loadReleaseConfig,
   execCommands,
   currentCommitId,
-  rollbackCommit
+  rollbackCommit,
+  versionTransformer
 };

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -7,12 +7,12 @@ const {
   DEFAULT_CONFIG_PATH
 } = require('./constants');
 const {
-  packageJson,
   buildReleaseEnvironment,
   loadReleaseConfig,
   execCommands,
   currentCommitId,
-  rollbackCommit
+  rollbackCommit,
+  versionTransformer
 } = require('./index');
 const config = require('./config');
 const validations = require('./validations');
@@ -33,25 +33,6 @@ const mockTestRunner = testRunner =>
       }
     })
   );
-
-describe('packageJson', () => {
-  it('returns the package.json as a JSON object', () => {
-    require('fs').__setReadFileSyncReturnValue(
-      'package.json',
-      JSON.stringify({
-        scripts: {
-          test: 'jest'
-        }
-      })
-    );
-
-    expect(packageJson()).toEqual({
-      scripts: {
-        test: 'jest'
-      }
-    });
-  });
-});
 
 describe('buildReleaseEnvironment', () => {
   const baseOptions = {};
@@ -315,5 +296,25 @@ describe('rollbackCommit', () => {
     );
 
     execSync.mockClear();
+  });
+});
+
+describe('versionTransformer', () => {
+  describe('when isFinal flag is true', () => {
+    const isFinal = true;
+
+    it('returns the version with the "v" prefix', () => {
+      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('v9.11.1');
+      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
+    });
+  });
+
+  describe('when isFinal flag is false', () => {
+    const isFinal = false;
+
+    it('returns the version as input by the user', () => {
+      expect(versionTransformer('9.11.1', [], { isFinal })).toBe('9.11.1');
+      expect(versionTransformer('v9.11.1', [], { isFinal })).toBe('v9.11.1');
+    });
   });
 });

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -7,6 +7,7 @@ const {
   DEFAULT_CONFIG_PATH
 } = require('./constants');
 const {
+  packageJson,
   buildReleaseEnvironment,
   loadReleaseConfig,
   execCommands,
@@ -32,6 +33,25 @@ const mockTestRunner = testRunner =>
       }
     })
   );
+
+describe('packageJson', () => {
+  it('returns the package.json as a JSON object', () => {
+    require('fs').__setReadFileSyncReturnValue(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          test: 'jest'
+        }
+      })
+    );
+
+    expect(packageJson()).toEqual({
+      scripts: {
+        test: 'jest'
+      }
+    });
+  });
+});
 
 describe('buildReleaseEnvironment', () => {
   const baseOptions = {};

--- a/src/utils/package/index.js
+++ b/src/utils/package/index.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const { PACKAGE_JSON_PATH } = require('../constants');
+
+let pkg;
+const packageJson = () => {
+  if (pkg) return pkg;
+
+  pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+
+  return pkg;
+};
+
+module.exports = {
+  packageJson
+};

--- a/src/utils/package/index.spec.js
+++ b/src/utils/package/index.spec.js
@@ -1,0 +1,22 @@
+const { packageJson } = require('./index');
+
+jest.mock('fs');
+
+describe('packageJson', () => {
+  it('returns the package.json as a JSON object', () => {
+    require('fs').__setReadFileSyncReturnValue(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          test: 'jest'
+        }
+      })
+    );
+
+    expect(packageJson()).toEqual({
+      scripts: {
+        test: 'jest'
+      }
+    });
+  });
+});

--- a/src/utils/validations/index.js
+++ b/src/utils/validations/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { packageJson } = require('../');
+const { packageJson } = require('../package');
 const {
   VALID_TEST_RUNNERS,
   GIT_PATH,

--- a/src/utils/validations/index.js
+++ b/src/utils/validations/index.js
@@ -1,5 +1,10 @@
 const fs = require('fs');
+const { packageJson } = require('../');
 const {
+  VALID_TEST_RUNNERS,
+  GIT_PATH,
+  NVM_PATH,
+  NVM_CONFIG_PATH,
   PACKAGE_JSON_PATH,
   LERNA_JSON_PATH
 } = require('../constants');
@@ -26,11 +31,37 @@ const validateLerna = () => {
   );
 };
 
-const isBuildDefined = pkg => pkg.scripts && pkg.scripts.build;
+const isGitProject = () => fs.existsSync(GIT_PATH);
+
+const isNvmInstalled = () => fs.existsSync(NVM_PATH);
+
+const nvmrcExists = () => fs.existsSync(NVM_CONFIG_PATH);
+
+const hasBuildScript = () => {
+  const pkg = packageJson();
+  if (!pkg.scripts) {
+    return false;
+  }
+
+  return 'build' in pkg.scripts;
+};
+
+const hasCiScript = () => {
+  const pkg = packageJson();
+  if (!pkg.scripts) {
+    return false;
+  }
+
+  return VALID_TEST_RUNNERS.some(testRunner => testRunner in pkg.scripts);
+};
 
 module.exports = {
   validatePkgRoot,
   validateTestRunner,
   validateLerna,
-  isBuildDefined
+  isGitProject,
+  isNvmInstalled,
+  nvmrcExists,
+  hasBuildScript,
+  hasCiScript
 };

--- a/src/utils/validations/index.js
+++ b/src/utils/validations/index.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const {
-  VERSIONS,
   PACKAGE_JSON_PATH,
   LERNA_JSON_PATH
 } = require('../constants');

--- a/src/utils/validations/index.spec.js
+++ b/src/utils/validations/index.spec.js
@@ -1,4 +1,4 @@
-const utils = require('../');
+const utils = require('../package');
 const { VALID_TEST_RUNNERS, NVM_PATH } = require('../constants');
 const {
   validatePkgRoot,
@@ -12,7 +12,7 @@ const {
 } = require('./');
 
 jest.mock('fs');
-jest.mock('../');
+jest.mock('../package');
 
 describe('validatePkgRoot', () => {
   beforeEach(() => {

--- a/src/utils/validations/index.spec.js
+++ b/src/utils/validations/index.spec.js
@@ -1,11 +1,18 @@
+const utils = require('../');
+const { VALID_TEST_RUNNERS, NVM_PATH } = require('../constants');
 const {
   validatePkgRoot,
   validateTestRunner,
   validateLerna,
-  isBuildDefined
+  isGitProject,
+  isNvmInstalled,
+  nvmrcExists,
+  hasBuildScript,
+  hasCiScript
 } = require('./');
 
 jest.mock('fs');
+jest.mock('../');
 
 describe('validatePkgRoot', () => {
   beforeEach(() => {
@@ -73,24 +80,124 @@ describe('validateLerna', () => {
   });
 });
 
-describe('isBuildDefined', () => {
-  describe('when build is defined in package.json', () => {
-    const mockPkg = {
-      scripts: {
-        build: 'babel'
-      }
-    };
+describe('isGitProject', () => {
+  afterEach(() => {
+    require('fs').__setMockFiles([]);
+  });
+
+  describe('when .git directory exists', () => {
+    const MOCKED_FILES = ['.git'];
 
     it('returns true', () => {
-      expect(isBuildDefined(mockPkg)).toBeTruthy();
+      require('fs').__setMockFiles(MOCKED_FILES);
+
+      expect(isGitProject()).toBe(true);
     });
   });
 
-  describe('when build is not defined in package.json', () => {
-    const mockPkg = {};
-
+  describe('when .git directory does not exist', () => {
     it('returns false', () => {
-      expect(isBuildDefined(mockPkg)).toBeFalsy();
+      expect(isGitProject()).toBe(false);
+    });
+  });
+});
+
+describe('isNvmInstalled', () => {
+  afterEach(() => {
+    require('fs').__setMockFiles([]);
+  });
+
+  describe('when ~/.nvm directory exists', () => {
+    const MOCKED_FILES = [NVM_PATH];
+
+    it('returns true', () => {
+      require('fs').__setMockFiles(MOCKED_FILES);
+
+      expect(isNvmInstalled()).toBe(true);
+    });
+  });
+
+  describe('when ~/.nvm directory does not exist', () => {
+    it('returns false', () => {
+      expect(isNvmInstalled()).toBe(false);
+    });
+  });
+});
+
+describe('nvmrcExists', () => {
+  afterEach(() => {
+    require('fs').__setMockFiles([]);
+  });
+
+  describe('when .nvmrc file exists', () => {
+    const MOCKED_FILES = ['.nvmrc'];
+
+    it('returns true', () => {
+      require('fs').__setMockFiles(MOCKED_FILES);
+
+      expect(nvmrcExists()).toBe(true);
+    });
+  });
+
+  describe('when .nvmrc file does not exist', () => {
+    it('returns false', () => {
+      expect(nvmrcExists()).toBe(false);
+    });
+  });
+});
+
+describe('hasBuildScript', () => {
+  describe('when a build script is defined in package.json', () => {
+    it('returns false', () => {
+      utils.packageJson.mockReturnValue({ scripts: { build: 'webpack' } });
+
+      expect(hasBuildScript()).toBe(true);
+    });
+  });
+
+  describe('when a build script is not defined in package.json', () => {
+    it('returns false', () => {
+      utils.packageJson.mockReturnValue({ scripts: {} });
+
+      expect(hasBuildScript()).toBe(false);
+    });
+  });
+
+  describe('when scripts are not defined in package.json', () => {
+    it('returns false', () => {
+      utils.packageJson.mockReturnValue({});
+
+      expect(hasBuildScript()).toBe(false);
+    });
+  });
+});
+
+describe('hasCiScript', () => {
+  for (const testRunner of VALID_TEST_RUNNERS) {
+    describe(`when a ${testRunner} script is defined in package.json`, () => {
+      it('returns true', () => {
+        utils.packageJson.mockReturnValue({
+          scripts: { ci: 'eslint && jest' }
+        });
+
+        expect(hasCiScript()).toBe(true);
+      });
+    });
+  }
+
+  describe('when a valid test runner script is not defined in package.json', () => {
+    it('returns false', () => {
+      utils.packageJson.mockReturnValue({ scripts: {} });
+
+      expect(hasCiScript()).toBe(false);
+    });
+  });
+
+  describe('when scripts are not defined in package.json', () => {
+    it('returns false', () => {
+      utils.packageJson.mockReturnValue({});
+
+      expect(hasCiScript()).toBe(false);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -630,6 +635,11 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 check-node-version@3.2.0:
   version "3.2.0"
@@ -1217,6 +1227,15 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -1616,6 +1635,13 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -1661,6 +1687,25 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+inquirer@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
+  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.0.0"
+    through "^2.3.6"
 
 inquirer@^3.0.6:
   version "3.3.0"
@@ -3486,6 +3531,11 @@ semver-compare@^1.0.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
+semver@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3744,6 +3794,13 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+  dependencies:
+    ansi-regex "^4.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The repo's `README` is a little bit difficult to understand when it comes to the setup, since there is so many assumptions this tool has:

- the existence of a `.nvmrc` file,
- the existence of a `ci` or `travis` script in `package.json`,
- the release branch is called `master`.

To improve the adoption rate of the tool, this PR implements a setup script that will guide the user in setting the project up correctly.

cc: @sunesimonsen 