### PR TITLE
Order branches during the release branch selection setup process

### DIFF
--- a/src/setup/release-branch/index.js
+++ b/src/setup/release-branch/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const childProcess = require('child_process');
 const { ask, addScript } = require('../utils');
+const { DEFAULT_BRANCH } = require('../../utils/constants');
 
 const GIT_PATH = path.resolve(process.env.PWD, '.git');
 
@@ -18,8 +19,16 @@ const gitBranches = () => {
     match = branchesRegex.exec(rawBranches);
   }
 
-  return branches;
+  return prioritizeDefaultBranch(branches);
 };
+
+const prioritizeDefaultBranch = branches => {
+  const index = branches.indexOf(DEFAULT_BRANCH);
+
+  return index === -1
+    ? branches
+    : branches.splice(index, 1).concat(branches);
+}
 
 const question = () => ({
   type: 'list',

--- a/src/setup/release-branch/index.spec.js
+++ b/src/setup/release-branch/index.spec.js
@@ -35,14 +35,14 @@ describe('gitBranches', () => {
     master
     my-branch-123`;
 
-    it('returns the git branches correctly', () => {
+    it('returns the git branches in the correct order', () => {
       require('child_process').__setReturnValues({
         'git branch': rawBranches
       });
 
       expect(gitBranches()).toEqual([
-        'abc-branch-xyz',
         'master',
+        'abc-branch-xyz',
         'my-branch-123'
       ]);
     });
@@ -53,14 +53,32 @@ describe('gitBranches', () => {
     * master
     my-branch-123`;
 
-    it('returns the git branches correctly', () => {
+    it('returns the git branches in the correct order', () => {
+      require('child_process').__setReturnValues({
+        'git branch': rawBranches
+      });
+
+      expect(gitBranches()).toEqual([
+        'master',
+        'abc-branch-xyz',
+        'my-branch-123'
+      ]);
+    });
+  });
+
+  describe('when master is not in the list of branches', () => {
+    const rawBranches = `abc-branch-xyz
+    * production
+    my-branch-123`;
+
+    it('returns the git branches in the correct order', () => {
       require('child_process').__setReturnValues({
         'git branch': rawBranches
       });
 
       expect(gitBranches()).toEqual([
         'abc-branch-xyz',
-        'master',
+        'production',
         'my-branch-123'
       ]);
     });


### PR DESCRIPTION
This PR sets the master branch to the front of the list of selectable branches for convenience.

For context: https://github.com/zendesk/node-publisher/pull/32#discussion_r316558052