### PR TITLE
Fix the generated config for custom release branches

### DIFF
--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -18,12 +18,14 @@ const buildReleaseConfig = env => {
     ],
     test: [`${scriptRunner} ${env.testRunner}`],
     build: null,
-    after_publish: ['git push --follow-tags origin master:master'],
+    after_publish: [
+      `git push --follow-tags origin ${env.branch}:${env.branch}`
+    ],
     changelog: [
       `${binPathPrefix}offline-github-changelog > CHANGELOG.md`,
       'git add CHANGELOG.md',
       'git commit --allow-empty -m "Update changelog"',
-      'git push origin master:master'
+      `git push origin ${env.branch}:${env.branch}`
     ]
   };
 


### PR DESCRIPTION
The release to custom branches would not have been worked as it was trying to push to master regardless of the configuration.