### PR TITLE
Fix reading the contents of .nvmrc

### DIFF
--- a/src/utils/validations/index.js
+++ b/src/utils/validations/index.js
@@ -10,7 +10,7 @@ const {
 } = require('../constants');
 
 const validateNodeVersion = () => {
-  const expectedNodeVersion = fs.readFileSync(NVM_CONFIG_PATH).trim();
+  const expectedNodeVersion = fs.readFileSync(NVM_CONFIG_PATH, { encoding: 'utf-8' }).trim();
   const actualNodeVersion = execSync('node -v', { encoding: 'utf-8' }).trim();
 
   if (expectedNodeVersion !== actualNodeVersion) {


### PR DESCRIPTION
Without specifying the encoding, `readFileSync` returns a buffer, even though `utf-8` is the default encoding 🤷 