### PR TITLE
Run different publish command based on yarn version

### DIFF
--- a/src/client/yarn.js
+++ b/src/client/yarn.js
@@ -1,5 +1,27 @@
+const { execSync } = require('child_process');
+
+const getYarnVersion = () => {
+  try {
+    const output = execSync('yarn --version', { encoding: 'utf8' });
+    return output.trim();
+  } catch (error) {
+    // Default to yarn v1 if version detection fails
+    return '1.0.0';
+  }
+};
+
+const isYarnV2OrHigher = () => {
+  const version = getYarnVersion();
+  const majorVersion = parseInt(version.split('.')[0], 10);
+  return majorVersion >= 2;
+};
+
 const publish = ({ nextVersion, execCommand }) => {
-  execCommand(`yarn publish --new-version ${nextVersion}`);
+  if (isYarnV2OrHigher()) {
+    execCommand(`yarn npm publish --tag ${nextVersion}`);
+  } else {
+    execCommand(`yarn publish --new-version ${nextVersion}`);
+  }
 };
 
 module.exports = {

--- a/src/client/yarn.spec.js
+++ b/src/client/yarn.spec.js
@@ -1,32 +1,106 @@
 const { publish } = require('./yarn');
 
+// Mock execSync to control yarn version detection
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+const { execSync } = require('child_process');
+
 describe('publish', () => {
-  describe('without preid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with yarn v1', () => {
+    beforeEach(() => {
+      execSync.mockReturnValue('1.22.10');
+    });
+
+    describe('without preid', () => {
+      const options = {
+        nextVersion: 'patch',
+        preid: undefined,
+        execCommand: jest.fn()
+      };
+
+      it('publishes new version using yarn v1 syntax', () => {
+        expect(() => publish(options)).not.toThrow();
+        expect(options.execCommand.mock.calls[0][0]).toBe(
+          'yarn publish --new-version patch'
+        );
+      });
+    });
+
+    describe('with preid', () => {
+      const options = {
+        nextVersion: 'major',
+        preid: 'alpha',
+        execCommand: jest.fn()
+      };
+
+      it('publishes new version using yarn v1 syntax', () => {
+        expect(() => publish(options)).not.toThrow();
+        expect(options.execCommand.mock.calls[0][0]).toBe(
+          'yarn publish --new-version major'
+        );
+      });
+    });
+  });
+
+  describe('with yarn v2+', () => {
+    beforeEach(() => {
+      execSync.mockReturnValue('4.1.0');
+    });
+
+    describe('without preid', () => {
+      const options = {
+        nextVersion: 'patch',
+        preid: undefined,
+        execCommand: jest.fn()
+      };
+
+      it('publishes new version using yarn v2+ syntax', () => {
+        expect(() => publish(options)).not.toThrow();
+        expect(options.execCommand.mock.calls[0][0]).toBe(
+          'yarn npm publish --tag patch'
+        );
+      });
+    });
+
+    describe('with preid', () => {
+      const options = {
+        nextVersion: 'major',
+        preid: 'alpha',
+        execCommand: jest.fn()
+      };
+
+      it('publishes new version using yarn v2+ syntax', () => {
+        expect(() => publish(options)).not.toThrow();
+        expect(options.execCommand.mock.calls[0][0]).toBe(
+          'yarn npm publish --tag major'
+        );
+      });
+    });
+  });
+
+  describe('when yarn version detection fails', () => {
+    beforeEach(() => {
+      execSync.mockImplementation(() => {
+        throw new Error('Command failed');
+      });
+    });
+
     const options = {
       nextVersion: 'patch',
       preid: undefined,
       execCommand: jest.fn()
     };
 
-    it('publishes new version without a prerelease id', () => {
+    it('defaults to yarn v1 syntax', () => {
       expect(() => publish(options)).not.toThrow();
       expect(options.execCommand.mock.calls[0][0]).toBe(
         'yarn publish --new-version patch'
-      );
-    });
-  });
-
-  describe('with preid', () => {
-    const options = {
-      nextVersion: 'major',
-      preid: 'alpha',
-      execCommand: jest.fn()
-    };
-
-    it('publishes new version without a prerelease id', () => {
-      expect(() => publish(options)).not.toThrow();
-      expect(options.execCommand.mock.calls[0][0]).toBe(
-        'yarn publish --new-version major'
       );
     });
   });


### PR DESCRIPTION
Starting with yarn v2, the publish command changed to `yarn npm publish`: https://yarnpkg.com/cli/npm/publish

This PR adds support for the new command.