### PR TITLE
Fix yarn v2+ versioning

### DIFF
--- a/src/client/yarn.js
+++ b/src/client/yarn.js
@@ -18,7 +18,8 @@ const isYarnV2OrHigher = () => {
 
 const publish = ({ nextVersion, execCommand }) => {
   if (isYarnV2OrHigher()) {
-    execCommand(`yarn npm publish --tag ${nextVersion}`);
+    execCommand(`yarn version ${nextVersion}`);
+    execCommand(`yarn npm publish`);
   } else {
     execCommand(`yarn publish --new-version ${nextVersion}`);
   }

--- a/src/client/yarn.spec.js
+++ b/src/client/yarn.spec.js
@@ -62,9 +62,8 @@ describe('publish', () => {
 
       it('publishes new version using yarn v2+ syntax', () => {
         expect(() => publish(options)).not.toThrow();
-        expect(options.execCommand.mock.calls[0][0]).toBe(
-          'yarn npm publish --tag patch'
-        );
+        expect(options.execCommand.mock.calls[0][0]).toBe('yarn version patch');
+        expect(options.execCommand.mock.calls[1][0]).toBe('yarn npm publish');
       });
     });
 
@@ -77,9 +76,8 @@ describe('publish', () => {
 
       it('publishes new version using yarn v2+ syntax', () => {
         expect(() => publish(options)).not.toThrow();
-        expect(options.execCommand.mock.calls[0][0]).toBe(
-          'yarn npm publish --tag major'
-        );
+        expect(options.execCommand.mock.calls[0][0]).toBe('yarn version major');
+        expect(options.execCommand.mock.calls[1][0]).toBe('yarn npm publish');
       });
     });
   });


### PR DESCRIPTION
Yarn v2+ bumps the version similar to npm now, as seen in the documentation:
https://yarnpkg.com/cli/version
https://yarnpkg.com/cli/npm/publish

This PR fixes the previous solution, as "--tag" is used for something different.