### PR TITLE
Fix missing method

### DIFF
--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -1,6 +1,6 @@
 const yaml = require('js-yaml');
 
-const readReleaseConfig = str => yaml.safeLoad(str);
+const readReleaseConfig = str => yaml.load(str);
 
 const buildReleaseConfig = env => {
   const client = env.npmClient === 'yarn-berry' ? 'yarn' : env.npmClient;


### PR DESCRIPTION
`safeLoad` is no longer supported, `load` is safe by default.