### PR TITLE
fix: resolve dependabot alert #109 (form-data CRLF injection)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "resolutions": {
     "tmp": "^0.2.6",
-    "form-data": "^3.0.4",
+    "form-data": "^3.0.5",
     "lodash": "^4.18.1",
     "flatted": "^3.4.2",
     "filelist/**/minimatch": "^5.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,15 +2149,15 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-form-data@^3.0.0, form-data@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.4.tgz#938273171d3f999286a4557528ce022dc2c98df1"
-  integrity sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==
+form-data@^3.0.0, form-data@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.5.tgz#2ea3ec24f0dcb7e0262a11efb732031240ea8e9f"
+  integrity sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.35"
 
 fs-extra@^10.0.0:
@@ -2391,6 +2391,13 @@ hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 


### PR DESCRIPTION
## Summary

Resolves high-severity Dependabot alert [#109](https://github.com/zendesk/node-publisher/security/dependabot/109) — CRLF injection in `form-data` (GHSA-hmw2-7cc7-3qxx).

`form-data` is a transitive dev dependency (`jest → jsdom → form-data`). `jsdom` declares `^3.0.0`, so the patched `3.0.5` is in range. The existing `resolutions` pin was `^3.0.4`, which still permitted the vulnerable `3.0.4`; bumping it to `^3.0.5` forces the patched version in the lockfile.

## Changes
- `package.json`: `resolutions.form-data` `^3.0.4` → `^3.0.5`
- `yarn.lock`: `form-data` now resolves to `3.0.5`

## Test plan
- [x] `yarn install` completes; `yarn why form-data` → `3.0.5`
- [x] `yarn test` — 85 tests pass
- [x] `yarn lint` — clean