### PR TITLE
Convert npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,14 +3,20 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
-  packages: read
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
-    with:
-      node_version: '22'
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: yarn npm publish

--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -1,0 +1,16 @@
+name: npm trusted publishing
+on:
+  workflow_dispatch:
+
+jobs:
+  bootstrap:
+    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+    with:
+      package-name: node-publisher
+      package-json-file-path: package.json
+      publish-workflow: npm-publish.yml
+      repository: ${{ github.repository }}
+      github-environment: npm-publish

--- a/.github/workflows/npm-trusted-publishing.yml
+++ b/.github/workflows/npm-trusted-publishing.yml
@@ -2,6 +2,9 @@ name: npm trusted publishing
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bootstrap:
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main

--- a/README.md
+++ b/README.md
@@ -174,17 +174,21 @@ yarn
 
 ## Release a new version
 
-`node-publisher` is published to npm from CI via the [`npm publish`](.github/workflows/npm-publish.yml) GitHub Actions workflow — no local npm login is required.
+`node-publisher` is published to npm from CI via the [`npm publish`](.github/workflows/npm-publish.yml) GitHub Actions workflow. Publishing is **tokenless** — it uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) over GitHub OIDC, so no npm token or local npm login is required.
 
 1. **Bump the version in a PR.** Run `yarn version <patch|minor|major>` (this edits the `version` field in `package.json`; it does not create a commit or tag), or edit the field by hand. Commit, open a PR, and merge to `master`.
-2. **Publish.** Go to **Actions → npm publish → Run workflow** and run it against `master`. This calls the shared [`zendesk/gw`](https://github.com/zendesk/gw/blob/main/.github/workflows/npm-publication.yml) reusable workflow, which builds the package and runs `yarn npm publish` to the Zendesk npmjs org.
+2. **Publish.** Go to **Actions → npm publish → Run workflow** and run it against `master`. The workflow builds the package and runs `yarn npm publish` to the Zendesk npmjs org, authenticating via OIDC.
 
 > **Note:** publishing is restricted to the required reviewers configured on the `npm-publish` GitHub environment. Only those admins can approve and run a release.
 
 **Prerequisites:**
 
-- The `npm-publish` GitHub environment must exist on the repository with the `NPM_TOKEN` and `NPM_TOTP_DEVICE` secrets configured (managed via #ask-packaging).
+- The `npm-publish` GitHub environment must exist on the repository (managed via #ask-packaging). The `NPM_TOKEN` and `NPM_TOTP_DEVICE` secrets are only needed for the one-time trusted-publisher setup below, not for regular publishes.
 - The `version` in `package.json` must be higher than the latest version already on [npmjs.com](https://www.npmjs.com/package/node-publisher) — npm rejects re-publishing an existing version.
+
+**First-time setup (once per package):**
+
+Before the first OIDC publish, the trusted publisher must be registered on npm. After the `npm-publish` environment and its `NPM_TOKEN`/`NPM_TOTP_DEVICE` secrets exist, run **Actions → npm trusted publishing → Run workflow** against `master` once. This registers this repository, the `npm-publish.yml` workflow, and the `npm-publish` environment with npm. After it succeeds, all releases publish tokenlessly via step 2 above.
 
 # Contributing
 


### PR DESCRIPTION
## Summary
- Adds `npm-trusted-publishing.yml` — one-time `workflow_dispatch` bootstrap that calls `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main` to register this repo + `npm-publish.yml` + the `npm-publish` environment as a trusted publisher on npm.
- Rewrites `npm-publish.yml` to publish via GitHub OIDC (tokenless): self-contained job with `permissions: id-token: write`, Node from `.nvmrc`, `corepack enable`, `yarn npm publish`. No `NPM_TOKEN`/`NPM_TOTP_DEVICE` in the steady-state publish.
- Updates the README release section to document tokenless publishing and the one-time trusted-publisher setup.

Follows the [trusted-publishing guide](https://zendeskdev.zendesk.com/hc/en-us/articles/10928235286426). Eligibility: yarn 4.17.1 ≥ 4.10.3 and Node 22.16.0 ≥ 22.14.0.

## Operational notes
- The `npm-publish` environment + `NPM_TOKEN`/`NPM_TOTP_DEVICE` secrets must exist first (needed only for the one-time bootstrap). Then run **npm trusted publishing** once; after that, releases publish via **npm publish** with no token.
- The registration binds to the exact workflow filename `npm-publish.yml` and environment `npm-publish` — renaming either breaks OIDC auth.

## Test plan
- [ ] `repo-checks` CI passes on the branch
- [ ] Run **npm trusted publishing** once (after env/secrets exist); confirm "Trusted publisher configured"
- [ ] Bump version in a PR, merge, run **npm publish**; confirm tokenless publish and new version on npmjs.com