### PR TITLE
Fix dependabot alerts #116, #117 (js-yaml, brace-expansion DoS)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,12 +1404,12 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.13":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
@@ -4358,14 +4358,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps transitive `brace-expansion` (via minimatch) from 1.1.15 to 1.1.18, fixing [GHSA-3jxr-9vmj-r5cp](https://github.com/zendesk/node-publisher/security/dependabot/117) (exponential-time DoS)
- Bumps transitive `js-yaml` (via eslint/cosmiconfig/istanbuljs) from 3.14.1 to 3.15.1, fixing [GHSA-52cp-r559-cp3m](https://github.com/zendesk/node-publisher/security/dependabot/116) (quadratic CPU DoS via merge-key chains)
- Both fixes were within existing semver ranges of the parent packages, resolved via `yarn up -R js-yaml brace-expansion` — no `package.json` changes needed

## Test plan
- [x] `yarn test` — 85 tests pass
- [x] `yarn lint` — clean

risk:none